### PR TITLE
fix: render multi-mesh GLB models in Scene Editor (#2)

### DIFF
--- a/berrycode/src/app/ecs_inspector.rs
+++ b/berrycode/src/app/ecs_inspector.rs
@@ -580,10 +580,7 @@ impl BerryCodeApp {
                 .values()
                 .find(|e| e.name == *name)
                 .and_then(|e| {
-                    crate::app::scene_editor::mesh_outline::triangles_for_entity(
-                        e,
-                        &self.root_path,
-                    )
+                    crate::app::scene_editor::mesh_outline::triangles_for_entity(e, &self.root_path)
                 });
 
             if let Some(triangles) = scene_match {
@@ -593,12 +590,7 @@ impl BerryCodeApp {
                     scale: [1.0, 1.0, 1.0],
                 };
                 crate::app::scene_editor::mesh_outline::draw_mesh_outline_with(
-                    &painter,
-                    &triangles,
-                    &world_t,
-                    project_v3,
-                    color,
-                    width,
+                    &painter, &triangles, &world_t, project_v3, color, width,
                 );
             } else {
                 let s = 0.5_f32;
@@ -613,9 +605,18 @@ impl BerryCodeApp {
                     [pos[0] - s, pos[1] + s, pos[2] + s],
                 ];
                 let edges = [
-                    (0, 1), (1, 2), (2, 3), (3, 0),
-                    (4, 5), (5, 6), (6, 7), (7, 4),
-                    (0, 4), (1, 5), (2, 6), (3, 7),
+                    (0, 1),
+                    (1, 2),
+                    (2, 3),
+                    (3, 0),
+                    (4, 5),
+                    (5, 6),
+                    (6, 7),
+                    (7, 4),
+                    (0, 4),
+                    (1, 5),
+                    (2, 6),
+                    (3, 7),
                 ];
                 let projected: Vec<egui::Pos2> = corners.iter().map(|c| project(*c)).collect();
                 for (a, b) in &edges {

--- a/berrycode/src/app/ecs_inspector.rs
+++ b/berrycode/src/app/ecs_inspector.rs
@@ -558,34 +558,13 @@ impl BerryCodeApp {
             egui::Stroke::new(1.5, egui::Color32::from_rgb(60, 60, 220)),
         );
 
-        // Draw entities as boxes
+        // Draw entities. When the entity name matches a scene-model entity
+        // with a renderable mesh component, draw its triangle outline using
+        // the shared `mesh_outline` helper. Otherwise fall back to a generic
+        // 1×1×1 wireframe cube so unknown / dynamically-spawned entities are
+        // still visible.
+        let project_v3 = |v: bevy::math::Vec3| project([v.x, v.y, v.z]);
         for (_eid, name, pos, is_selected) in &entity_positions {
-            let s = 0.5_f32; // box half-size
-            let corners = [
-                [pos[0] - s, pos[1] - s, pos[2] - s],
-                [pos[0] + s, pos[1] - s, pos[2] - s],
-                [pos[0] + s, pos[1] + s, pos[2] - s],
-                [pos[0] - s, pos[1] + s, pos[2] - s],
-                [pos[0] - s, pos[1] - s, pos[2] + s],
-                [pos[0] + s, pos[1] - s, pos[2] + s],
-                [pos[0] + s, pos[1] + s, pos[2] + s],
-                [pos[0] - s, pos[1] + s, pos[2] + s],
-            ];
-            let edges = [
-                (0, 1),
-                (1, 2),
-                (2, 3),
-                (3, 0),
-                (4, 5),
-                (5, 6),
-                (6, 7),
-                (7, 4),
-                (0, 4),
-                (1, 5),
-                (2, 6),
-                (3, 7),
-            ];
-
             let (color, width) = if *is_selected {
                 (egui::Color32::from_rgb(75, 180, 255), 2.0)
             } else {
@@ -595,16 +574,60 @@ impl BerryCodeApp {
                 )
             };
 
-            let projected: Vec<egui::Pos2> = corners.iter().map(|c| project(*c)).collect();
-            for (a, b) in &edges {
-                painter.line_segment(
-                    [projected[*a], projected[*b]],
-                    egui::Stroke::new(width, color),
+            let scene_match = self
+                .scene_model
+                .entities
+                .values()
+                .find(|e| e.name == *name)
+                .and_then(|e| {
+                    crate::app::scene_editor::mesh_outline::triangles_for_entity(
+                        e,
+                        &self.root_path,
+                    )
+                });
+
+            if let Some(triangles) = scene_match {
+                let world_t = crate::app::scene_editor::model::TransformData {
+                    translation: *pos,
+                    rotation_euler: [0.0, 0.0, 0.0],
+                    scale: [1.0, 1.0, 1.0],
+                };
+                crate::app::scene_editor::mesh_outline::draw_mesh_outline_with(
+                    &painter,
+                    &triangles,
+                    &world_t,
+                    project_v3,
+                    color,
+                    width,
                 );
+            } else {
+                let s = 0.5_f32;
+                let corners = [
+                    [pos[0] - s, pos[1] - s, pos[2] - s],
+                    [pos[0] + s, pos[1] - s, pos[2] - s],
+                    [pos[0] + s, pos[1] + s, pos[2] - s],
+                    [pos[0] - s, pos[1] + s, pos[2] - s],
+                    [pos[0] - s, pos[1] - s, pos[2] + s],
+                    [pos[0] + s, pos[1] - s, pos[2] + s],
+                    [pos[0] + s, pos[1] + s, pos[2] + s],
+                    [pos[0] - s, pos[1] + s, pos[2] + s],
+                ];
+                let edges = [
+                    (0, 1), (1, 2), (2, 3), (3, 0),
+                    (4, 5), (5, 6), (6, 7), (7, 4),
+                    (0, 4), (1, 5), (2, 6), (3, 7),
+                ];
+                let projected: Vec<egui::Pos2> = corners.iter().map(|c| project(*c)).collect();
+                for (a, b) in &edges {
+                    painter.line_segment(
+                        [projected[*a], projected[*b]],
+                        egui::Stroke::new(width, color),
+                    );
+                }
             }
 
             // Label
-            let label_pos = project([pos[0], pos[1] + s + 0.3, pos[2]]);
+            let label_pos = project([pos[0], pos[1] + 0.8, pos[2]]);
             let label_color = if *is_selected {
                 egui::Color32::WHITE
             } else {

--- a/berrycode/src/app/events.rs
+++ b/berrycode/src/app/events.rs
@@ -699,7 +699,7 @@ impl BerryCodeApp {
                     let mut count = 0;
                     for entity in self.scene_model.entities.values() {
                         let world_t = self.scene_model.compute_world_transform(entity.id);
-                        let aabb = aabb_for_entity(entity, &world_t);
+                        let aabb = aabb_for_entity(entity, &world_t, &self.root_path);
                         if aabb.is_some() {
                             count += 1;
                         }

--- a/berrycode/src/app/mod.rs
+++ b/berrycode/src/app/mod.rs
@@ -926,12 +926,7 @@ impl BerryCodeApp {
                 })
                 .and_then(|entry| {
                     let bscene_path = entry.path().to_string_lossy().to_string();
-                    std::fs::read_to_string(&bscene_path)
-                        .ok()
-                        .and_then(|content| {
-                            ron::from_str::<crate::app::scene_editor::model::SceneModel>(&content)
-                                .ok()
-                        })
+                    crate::app::scene_editor::serialization::load_scene_from_ron(&bscene_path).ok()
                 })
                 .map(|scene| {
                     let count = scene.entities.len();

--- a/berrycode/src/app/scene_editor/bevy_render.rs
+++ b/berrycode/src/app/scene_editor/bevy_render.rs
@@ -203,6 +203,39 @@ pub fn setup_scene_editor_render(
     state.orbit_distance = 8.0;
 }
 
+/// Propagate `RenderLayers::layer(2)` to children of `SceneEditorObject`
+/// entities. GLTF scenes loaded via `SceneRoot` spawn their child meshes
+/// asynchronously, so we detect newly-added children via `Added<ChildOf>` and
+/// walk up the ancestor chain to check whether they belong to the editor
+/// viewport. Without this, GLTF meshes spawned from `MeshFromFile` /
+/// `SkinnedMesh` / `LodGroup` would render on layer 0 and never reach the
+/// editor's off-screen camera (layer 2).
+pub fn propagate_scene_editor_render_layers(
+    new_children: Query<(Entity, &ChildOf), Added<ChildOf>>,
+    editor_markers: Query<&SceneEditorObject>,
+    ancestors: Query<&ChildOf>,
+    mut commands: Commands,
+) {
+    let target = RenderLayers::layer(2);
+    for (entity, _parent) in new_children.iter() {
+        let mut current = entity;
+        let mut is_editor = false;
+        for _ in 0..50 {
+            if editor_markers.get(current).is_ok() {
+                is_editor = true;
+                break;
+            }
+            match ancestors.get(current) {
+                Ok(p) => current = p.parent(),
+                Err(_) => break,
+            }
+        }
+        if is_editor {
+            commands.entity(entity).insert(target.clone());
+        }
+    }
+}
+
 /// Update the camera transform and projection each frame from the orbit
 /// parameters pushed in by the UI layer.
 pub fn update_scene_editor_camera(

--- a/berrycode/src/app/scene_editor/bevy_render.rs
+++ b/berrycode/src/app/scene_editor/bevy_render.rs
@@ -34,6 +34,13 @@ pub struct SceneEditorRender {
     /// Tracks which `SceneModel` entity id maps to which Bevy `Entity`
     /// (so the sync system can update or despawn them).
     pub spawned_entities: HashMap<u64, Entity>,
+    /// Per-entity GLB auto-fit scale factor. The key is the scene-model entity
+    /// id; the value is multiplied into the entity's `Transform.scale` on every
+    /// sync so that the user's authored scale stacks on top of the fit-to-view
+    /// factor. Entries are populated when an entity spawns with a `MeshFromFile`
+    /// / `SkinnedMesh` / `LodGroup` whose vertex bounds exceed 5 units, and are
+    /// cleared together with `spawned_entities` on respawn.
+    pub auto_fit_factors: HashMap<u64, f32>,
     /// Whether the directional light casts shadows.
     pub shadows_enabled: bool,
     /// Whether bloom post-processing is enabled.
@@ -93,6 +100,7 @@ impl Default for SceneEditorRender {
             ortho: false,
             ortho_scale: 0.0,
             spawned_entities: HashMap::new(),
+            auto_fit_factors: HashMap::new(),
             shadows_enabled: true,
             bloom_enabled: false,
             bloom_intensity: 0.3,

--- a/berrycode/src/app/scene_editor/bevy_sync.rs
+++ b/berrycode/src/app/scene_editor/bevy_sync.rs
@@ -40,6 +40,9 @@ pub fn sync_scene_to_bevy(
                 if let Ok(mut t) = transforms.get_mut(bevy_entity) {
                     let effective = effective_transform(&app, *id, scene_entity);
                     apply_transform(&mut t, &effective);
+                    if let Some(factor) = state.auto_fit_factors.get(id) {
+                        t.scale *= *factor;
+                    }
                 }
             }
         }
@@ -60,6 +63,7 @@ pub fn sync_scene_to_bevy(
         commands.entity(e).despawn();
     }
     state.spawned_entities.clear();
+    state.auto_fit_factors.clear();
 
     // Spawn each scene entity (skip disabled ones).
     for (id, scene_entity) in &app.scene_model.entities {
@@ -70,7 +74,7 @@ pub fn sync_scene_to_bevy(
         let effective = effective_transform(&app, *id, scene_entity);
         apply_transform(&mut transform, &effective);
 
-        let bevy_entity = spawn_scene_entity(
+        let (bevy_entity, auto_fit) = spawn_scene_entity(
             &mut commands,
             &mut meshes,
             &mut materials,
@@ -82,6 +86,9 @@ pub fn sync_scene_to_bevy(
         );
 
         state.spawned_entities.insert(*id, bevy_entity);
+        if let Some(factor) = auto_fit {
+            state.auto_fit_factors.insert(*id, factor);
+        }
     }
 
     state.last_sync_hash = current_hash;
@@ -158,7 +165,7 @@ fn spawn_scene_entity(
     scene_entity: &SceneEntity,
     id: u64,
     project_root: &str,
-) -> Entity {
+) -> (Entity, Option<f32>) {
     let mut entity = commands.spawn((
         transform,
         Visibility::default(),
@@ -167,6 +174,7 @@ fn spawn_scene_entity(
         RenderLayers::layer(2),
         Name::new(scene_entity.name.clone()),
     ));
+    let mut auto_fit: Option<f32> = None;
 
     for component in &scene_entity.components {
         match component {
@@ -364,6 +372,12 @@ fn spawn_scene_entity(
                     let scene_handle: Handle<Scene> = asset_server
                         .load(bevy::gltf::GltfAssetLabel::Scene(0).from_asset(rel_path));
                     entity.insert(SceneRoot(scene_handle));
+                    if let Some(factor) = compute_glb_auto_fit(&abs_path) {
+                        let mut t = transform;
+                        t.scale *= factor;
+                        entity.insert(t);
+                        auto_fit = Some(factor);
+                    }
                 } else {
                     if !abs_path.is_empty() {
                         tracing::warn!("Failed to stage GLB asset: {}", abs_path);
@@ -488,6 +502,12 @@ fn spawn_scene_entity(
                             let scene_handle: Handle<Scene> = asset_server
                                 .load(bevy::gltf::GltfAssetLabel::Scene(0).from_asset(rel_path));
                             entity.insert(SceneRoot(scene_handle));
+                            if let Some(factor) = compute_glb_auto_fit(&abs_path) {
+                                let mut t = transform;
+                                t.scale *= factor;
+                                entity.insert(t);
+                                auto_fit = Some(factor);
+                            }
                         }
                     }
                 }
@@ -523,6 +543,12 @@ fn spawn_scene_entity(
                         let scene_handle: Handle<Scene> = asset_server
                             .load(bevy::gltf::GltfAssetLabel::Scene(0).from_asset(rel_path));
                         entity.insert(SceneRoot(scene_handle));
+                        if let Some(factor) = compute_glb_auto_fit(&abs_path) {
+                            let mut t = transform;
+                            t.scale *= factor;
+                            entity.insert(t);
+                            auto_fit = Some(factor);
+                        }
                     }
                 }
             }
@@ -543,31 +569,61 @@ fn spawn_scene_entity(
         }
     }
 
-    entity.id()
+    (entity.id(), auto_fit)
 }
 
-/// Mesh positions extracted from a GLTF/GLB file (used for bounding-box and
-/// auto-scale calculations on the editor side).
+/// Mesh positions and triangle indices extracted from a GLTF/GLB file. Used
+/// for bounding-box / auto-scale calculations and for drawing mesh-outline
+/// overlays on selected entities. `indices` is always populated: when the
+/// primitive is unindexed, it is synthesized as `0,1,2,3,...` so callers can
+/// treat the data uniformly as a triangle list.
 pub struct GltfMeshData {
     pub positions: Vec<[f32; 3]>,
+    pub indices: Vec<u32>,
 }
 
-/// Extract vertex positions from the first primitive of the first mesh in a
-/// GLTF/GLB file. Pure function, no Bevy dependency. Used by the editor for
-/// fitting bounding boxes and computing auto-scale; runtime rendering goes
-/// through Bevy's `SceneRoot` pipeline.
+/// Extract vertex positions and triangle indices from the first primitive of
+/// the first mesh in a GLTF/GLB file. Pure function, no Bevy dependency.
 pub fn extract_gltf_mesh_data(file_path: &str) -> Option<GltfMeshData> {
     let (document, buffers, _images) = gltf::import(file_path).ok()?;
 
     let gltf_mesh = document.meshes().next()?;
     let primitive = gltf_mesh.primitives().next()?;
 
-    let positions: Vec<[f32; 3]> = {
-        let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
-        reader.read_positions()?.collect()
+    let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
+    let positions: Vec<[f32; 3]> = reader.read_positions()?.collect();
+    let indices: Vec<u32> = match reader.read_indices() {
+        Some(it) => it.into_u32().collect(),
+        None => (0..positions.len() as u32).collect(),
     };
 
-    Some(GltfMeshData { positions })
+    Some(GltfMeshData { positions, indices })
+}
+
+/// Compute a fit-to-view scale factor from the GLB's vertex bounds. Returns
+/// `Some(factor)` when the largest extent exceeds 5 units (i.e. the model is
+/// authored in centimeters or similar and would otherwise render huge);
+/// `None` for already-small models. The caller is expected to multiply this
+/// factor into the entity's `Transform.scale` and to re-apply it on every
+/// per-frame sync (since `apply_transform` overwrites scale wholesale).
+pub fn compute_glb_auto_fit(abs_path: &str) -> Option<f32> {
+    let data = extract_gltf_mesh_data(abs_path)?;
+    let mut min = [f32::MAX; 3];
+    let mut max = [f32::MIN; 3];
+    for p in &data.positions {
+        for i in 0..3 {
+            min[i] = min[i].min(p[i]);
+            max[i] = max[i].max(p[i]);
+        }
+    }
+    let extent = (max[0] - min[0])
+        .max(max[1] - min[1])
+        .max(max[2] - min[2])
+        .max(0.001);
+    if extent <= 5.0 {
+        return None;
+    }
+    Some(2.0 / extent)
 }
 
 /// Stage a model file for loading by Bevy's `AssetServer`.

--- a/berrycode/src/app/scene_editor/bevy_sync.rs
+++ b/berrycode/src/app/scene_editor/bevy_sync.rs
@@ -21,7 +21,6 @@ pub fn sync_scene_to_bevy(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    mut images: ResMut<Assets<Image>>,
     asset_server: Res<AssetServer>,
     app: bevy::ecs::system::NonSend<BerryCodeApp>,
     mut state: ResMut<SceneEditorRender>,
@@ -75,7 +74,6 @@ pub fn sync_scene_to_bevy(
             &mut commands,
             &mut meshes,
             &mut materials,
-            &mut images,
             &asset_server,
             transform,
             scene_entity,
@@ -155,7 +153,6 @@ fn spawn_scene_entity(
     commands: &mut Commands,
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<StandardMaterial>,
-    images: &mut Assets<Image>,
     asset_server: &AssetServer,
     transform: Transform,
     scene_entity: &SceneEntity,
@@ -356,21 +353,21 @@ fn spawn_scene_entity(
                     }
                 };
 
-                let loaded = if !abs_path.is_empty() {
-                    tracing::info!("Loading GLB mesh: {}", abs_path);
-                    let result = load_gltf_mesh_for_bevy(&abs_path, meshes, materials, images);
-                    if result.is_none() {
-                        tracing::warn!("Failed to load GLB mesh: {}", abs_path);
-                    }
-                    result
-                } else {
+                let staged = if abs_path.is_empty() {
                     None
+                } else {
+                    stage_asset_for_loading(&abs_path)
                 };
 
-                if let Some((mesh_handle, mat_handle)) = loaded {
-                    tracing::info!("GLB mesh loaded successfully");
-                    entity.insert((Mesh3d(mesh_handle), MeshMaterial3d(mat_handle)));
+                if let Some(rel_path) = staged {
+                    tracing::info!("Loading GLB scene: {} (staged as {})", abs_path, rel_path);
+                    let scene_handle: Handle<Scene> = asset_server
+                        .load(bevy::gltf::GltfAssetLabel::Scene(0).from_asset(rel_path));
+                    entity.insert(SceneRoot(scene_handle));
                 } else {
+                    if !abs_path.is_empty() {
+                        tracing::warn!("Failed to stage GLB asset: {}", abs_path);
+                    }
                     // Fallback placeholder
                     let mesh = meshes.add(Cuboid::new(0.5, 0.5, 0.5));
                     let mat = materials.add(StandardMaterial {
@@ -480,16 +477,18 @@ fn spawn_scene_entity(
                 // Spawn the first (highest detail) level's mesh if available.
                 if let Some(first) = levels.first() {
                     if !first.mesh_path.is_empty() {
-                        let asset_path = if first.mesh_path.starts_with('/')
+                        let abs_path = if first.mesh_path.starts_with('/')
                             || first.mesh_path.contains(":\\")
                         {
-                            format!("file://{}", first.mesh_path)
-                        } else {
                             first.mesh_path.clone()
+                        } else {
+                            format!("{}/assets/{}", project_root, first.mesh_path)
                         };
-                        let scene_handle: Handle<Scene> =
-                            asset_server.load(format!("{}#Scene0", asset_path));
-                        entity.insert(SceneRoot(scene_handle));
+                        if let Some(rel_path) = stage_asset_for_loading(&abs_path) {
+                            let scene_handle: Handle<Scene> = asset_server
+                                .load(bevy::gltf::GltfAssetLabel::Scene(0).from_asset(rel_path));
+                            entity.insert(SceneRoot(scene_handle));
+                        }
                     }
                 }
             }
@@ -515,14 +514,16 @@ fn spawn_scene_entity(
             ComponentData::SkinnedMesh { path, .. } => {
                 // Load the GLB/GLTF as a scene, similar to MeshFromFile.
                 if !path.is_empty() {
-                    let asset_path = if path.starts_with('/') || path.contains(":\\") {
-                        format!("file://{}", path)
-                    } else {
+                    let abs_path = if path.starts_with('/') || path.contains(":\\") {
                         path.clone()
+                    } else {
+                        format!("{}/assets/{}", project_root, path)
                     };
-                    let scene_handle: Handle<Scene> =
-                        asset_server.load(format!("{}#Scene0", asset_path));
-                    entity.insert(SceneRoot(scene_handle));
+                    if let Some(rel_path) = stage_asset_for_loading(&abs_path) {
+                        let scene_handle: Handle<Scene> = asset_server
+                            .load(bevy::gltf::GltfAssetLabel::Scene(0).from_asset(rel_path));
+                        entity.insert(SceneRoot(scene_handle));
+                    }
                 }
             }
             ComponentData::VisualScript { .. } => {
@@ -545,173 +546,65 @@ fn spawn_scene_entity(
     entity.id()
 }
 
-/// Extracted GLTF mesh data (testable without Bevy Assets).
+/// Mesh positions extracted from a GLTF/GLB file (used for bounding-box and
+/// auto-scale calculations on the editor side).
 pub struct GltfMeshData {
     pub positions: Vec<[f32; 3]>,
-    pub normals: Vec<[f32; 3]>,
-    pub uvs: Vec<[f32; 2]>,
-    pub indices: Option<Vec<u32>>,
-    pub base_color: [f32; 4],
-    pub metallic: f32,
-    pub roughness: f32,
 }
 
-/// Extract mesh data from a GLTF/GLB file. Pure function, no Bevy dependency.
+/// Extract vertex positions from the first primitive of the first mesh in a
+/// GLTF/GLB file. Pure function, no Bevy dependency. Used by the editor for
+/// fitting bounding boxes and computing auto-scale; runtime rendering goes
+/// through Bevy's `SceneRoot` pipeline.
 pub fn extract_gltf_mesh_data(file_path: &str) -> Option<GltfMeshData> {
     let (document, buffers, _images) = gltf::import(file_path).ok()?;
 
     let gltf_mesh = document.meshes().next()?;
     let primitive = gltf_mesh.primitives().next()?;
 
-    // Read each attribute with a fresh reader (reader is consumed by iterators)
     let positions: Vec<[f32; 3]> = {
         let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
         reader.read_positions()?.collect()
     };
 
-    let normals: Vec<[f32; 3]> = {
-        let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
-        reader
-            .read_normals()
-            .map(|n| n.collect())
-            .unwrap_or_else(|| vec![[0.0, 1.0, 0.0]; positions.len()])
-    };
-
-    let uvs: Vec<[f32; 2]> = {
-        let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
-        reader
-            .read_tex_coords(0)
-            .map(|tc| tc.into_f32().collect())
-            .unwrap_or_else(|| vec![[0.0, 0.0]; positions.len()])
-    };
-
-    let indices: Option<Vec<u32>> = {
-        let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
-        reader.read_indices().map(|i| i.into_u32().collect())
-    };
-
-    let mat = primitive.material();
-    let pbr = mat.pbr_metallic_roughness();
-    let base = pbr.base_color_factor();
-
-    Some(GltfMeshData {
-        positions,
-        normals,
-        uvs,
-        indices,
-        base_color: base,
-        metallic: pbr.metallic_factor(),
-        roughness: pbr.roughness_factor(),
-    })
+    Some(GltfMeshData { positions })
 }
 
-/// Load a GLB/GLTF file directly and create Bevy Mesh + StandardMaterial with texture.
-fn load_gltf_mesh_for_bevy(
-    file_path: &str,
-    meshes: &mut Assets<Mesh>,
-    materials: &mut Assets<StandardMaterial>,
-    bevy_images: &mut Assets<Image>,
-) -> Option<(Handle<Mesh>, Handle<StandardMaterial>)> {
-    let (document, _buffers, gltf_images) = gltf::import(file_path).ok()?;
-    let data = extract_gltf_mesh_data(file_path)?;
+/// Stage a model file for loading by Bevy's `AssetServer`.
+///
+/// Bevy's default `AssetPlugin` only resolves paths under the `assets/`
+/// directory configured at startup. To load models the user picked from
+/// arbitrary disk locations, we copy the file into `assets/_preview/` and
+/// return a relative asset path.
+///
+/// Returns `None` if the source file is missing, empty, or the copy fails.
+fn stage_asset_for_loading(abs_path: &str) -> Option<String> {
+    let file_path = std::path::Path::new(abs_path);
+    let file_name = file_path.file_name()?.to_string_lossy().to_string();
 
-    // Auto-scale large models to fit in the scene (~2 unit size)
-    let mut min = [f32::MAX; 3];
-    let mut max = [f32::MIN; 3];
-    for p in &data.positions {
-        for i in 0..3 {
-            min[i] = min[i].min(p[i]);
-            max[i] = max[i].max(p[i]);
-        }
-    }
-    let extent = (max[0] - min[0])
-        .max(max[1] - min[1])
-        .max(max[2] - min[2])
-        .max(0.001);
-    let auto_scale = if extent > 5.0 { 2.0 / extent } else { 1.0 };
-    let center = [(min[0] + max[0]) * 0.5, min[1], (min[2] + max[2]) * 0.5];
-
-    let scaled_positions: Vec<[f32; 3]> = data
-        .positions
-        .iter()
-        .map(|p| {
-            [
-                (p[0] - center[0]) * auto_scale,
-                (p[1] - center[1]) * auto_scale,
-                (p[2] - center[2]) * auto_scale,
-            ]
-        })
-        .collect();
-
-    let mut bevy_mesh = Mesh::new(
-        bevy::mesh::PrimitiveTopology::TriangleList,
-        bevy::asset::RenderAssetUsages::MAIN_WORLD | bevy::asset::RenderAssetUsages::RENDER_WORLD,
-    );
-    bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, scaled_positions);
-    bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, data.normals);
-    bevy_mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, data.uvs);
-
-    if let Some(indices) = data.indices {
-        bevy_mesh.insert_indices(bevy::mesh::Indices::U32(indices));
-    }
-
-    let mesh_handle = meshes.add(bevy_mesh);
-
-    // Create texture from GLTF embedded image
-    let texture_handle: Option<Handle<Image>> = document
-        .meshes()
-        .next()
-        .and_then(|m| m.primitives().next())
-        .and_then(|prim| {
-            let pbr = prim.material().pbr_metallic_roughness();
-            pbr.base_color_texture()
-        })
-        .and_then(|tex_info| {
-            let img_idx = tex_info.texture().source().index();
-            let img = gltf_images.get(img_idx)?;
-            let rgba_pixels = match img.format {
-                gltf::image::Format::R8G8B8A8 => img.pixels.clone(),
-                gltf::image::Format::R8G8B8 => {
-                    let mut rgba = Vec::with_capacity(img.pixels.len() / 3 * 4);
-                    for chunk in img.pixels.chunks(3) {
-                        rgba.push(chunk[0]);
-                        rgba.push(chunk[1]);
-                        rgba.push(chunk[2]);
-                        rgba.push(255);
-                    }
-                    rgba
-                }
-                _ => return None,
-            };
-            let bevy_image = Image::new(
-                bevy::render::render_resource::Extent3d {
-                    width: img.width,
-                    height: img.height,
-                    depth_or_array_layers: 1,
-                },
-                bevy::render::render_resource::TextureDimension::D2,
-                rgba_pixels,
-                bevy::render::render_resource::TextureFormat::Rgba8UnormSrgb,
-                bevy::asset::RenderAssetUsages::MAIN_WORLD
-                    | bevy::asset::RenderAssetUsages::RENDER_WORLD,
-            );
-            Some(bevy_images.add(bevy_image))
+    let bevy_assets_dir = option_env!("CARGO_MANIFEST_DIR")
+        .map(|d| std::path::PathBuf::from(d).join("assets"))
+        .unwrap_or_else(|| {
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().map(|p| p.join("assets")))
+                .unwrap_or_else(|| std::path::PathBuf::from("assets"))
         });
 
-    let mat_handle = materials.add(StandardMaterial {
-        base_color: Color::srgba(
-            data.base_color[0],
-            data.base_color[1],
-            data.base_color[2],
-            data.base_color[3],
-        ),
-        base_color_texture: texture_handle,
-        metallic: data.metallic,
-        perceptual_roughness: data.roughness,
-        ..default()
-    });
+    let preview_dir = bevy_assets_dir.join("_preview");
+    std::fs::create_dir_all(&preview_dir).ok()?;
+    let dest = preview_dir.join(&file_name);
 
-    Some((mesh_handle, mat_handle))
+    let src_size = std::fs::metadata(abs_path).map(|m| m.len()).ok()?;
+    if src_size == 0 {
+        return None;
+    }
+    let dst_size = std::fs::metadata(&dest).map(|m| m.len()).unwrap_or(0);
+    if src_size != dst_size {
+        std::fs::copy(abs_path, &dest).ok()?;
+    }
+
+    Some(format!("_preview/{}", file_name))
 }
 
 fn compute_scene_hash(scene: &SceneModel) -> u64 {
@@ -1128,24 +1021,7 @@ mod tests {
         assert!(data.is_some(), "extract_gltf_mesh_data returned None");
         let data = data.unwrap();
         assert!(!data.positions.is_empty(), "No positions extracted");
-        assert_eq!(
-            data.positions.len(),
-            data.normals.len(),
-            "Position/normal count mismatch"
-        );
-        assert_eq!(
-            data.positions.len(),
-            data.uvs.len(),
-            "Position/uv count mismatch"
-        );
-        println!(
-            "fox.glb: {} positions, {} normals, {} uvs, indices: {:?}, base_color: {:?}",
-            data.positions.len(),
-            data.normals.len(),
-            data.uvs.len(),
-            data.indices.as_ref().map(|i| i.len()),
-            data.base_color,
-        );
+        println!("fox.glb: {} positions", data.positions.len());
     }
 
     #[test]

--- a/berrycode/src/app/scene_editor/gizmo.rs
+++ b/berrycode/src/app/scene_editor/gizmo.rs
@@ -181,10 +181,13 @@ pub fn ray_aabb_hit(
 
 /// Compute a world-space AABB for a scene entity based on its first renderable
 /// component. The caller must supply the entity's world-space transform (since
-/// `entity.transform` is now local-space).
+/// `entity.transform` is now local-space) and the project root so that
+/// `MeshFromFile` paths (which are stored relative to `assets/`) can be
+/// resolved to absolute paths for GLTF parsing.
 pub fn aabb_for_entity(
     entity: &SceneEntity,
     world_transform: &TransformData,
+    project_root: &str,
 ) -> Option<(Vec3, Vec3)> {
     let pos = Vec3::from_array(world_transform.translation);
     let scale = Vec3::from_array(world_transform.scale);
@@ -213,8 +216,18 @@ pub fn aabb_for_entity(
             ComponentData::MeshFromFile { path, .. } => {
                 // Try to get real bounds from GLTF data
                 if !path.is_empty() {
+                    let abs = if path.starts_with('/') || path.contains(":\\") {
+                        path.clone()
+                    } else {
+                        let with_assets = format!("{}/assets/{}", project_root, path);
+                        if std::path::Path::new(&with_assets).exists() {
+                            with_assets
+                        } else {
+                            format!("{}/{}", project_root, path)
+                        }
+                    };
                     if let Some(data) =
-                        crate::app::scene_editor::bevy_sync::extract_gltf_mesh_data(path)
+                        crate::app::scene_editor::bevy_sync::extract_gltf_mesh_data(&abs)
                     {
                         let mut bmin = [f32::MAX; 3];
                         let mut bmax = [f32::MIN; 3];

--- a/berrycode/src/app/scene_editor/mesh_outline.rs
+++ b/berrycode/src/app/scene_editor/mesh_outline.rs
@@ -1,0 +1,239 @@
+//! Per-triangle mesh-outline rendering for selected entities.
+//!
+//! Both the Scene Editor (selection wireframe) and the ECS Inspector (3D
+//! entity overview) use this to project a mesh's triangles into screen space
+//! and draw their edges, instead of falling back to a generic AABB cube.
+
+use crate::app::scene_editor::gizmo::project_to_screen;
+use crate::app::scene_editor::model::{ColliderShape, ComponentData, SceneEntity, TransformData};
+use bevy::math::{Quat, Vec3};
+
+/// Build the list of local-space triangles that represent an entity's first
+/// renderable component. Returns `None` for non-renderable entities (lights,
+/// data-only components, etc.) so the caller can fall back to a default
+/// gizmo. Paths inside `MeshFromFile` are resolved relative to
+/// `<project_root>/assets/`.
+pub fn triangles_for_entity(
+    entity: &SceneEntity,
+    project_root: &str,
+) -> Option<Vec<[Vec3; 3]>> {
+    for c in &entity.components {
+        match c {
+            ComponentData::MeshCube { size, .. } => {
+                return Some(cube_triangles(*size));
+            }
+            ComponentData::MeshSphere { radius, .. } => {
+                return Some(sphere_triangles(*radius, 12, 8));
+            }
+            ComponentData::MeshPlane { size, .. } => {
+                return Some(plane_triangles(*size));
+            }
+            ComponentData::MeshFromFile { path, .. } => {
+                if path.is_empty() {
+                    continue;
+                }
+                let abs = resolve_asset_path(path, project_root);
+                let data = crate::app::scene_editor::bevy_sync::extract_gltf_mesh_data(&abs)?;
+                let auto_fit = compute_auto_fit_factor(&data.positions);
+                let mut tris = Vec::with_capacity(data.indices.len() / 3);
+                for chunk in data.indices.chunks_exact(3) {
+                    let a = data.positions.get(chunk[0] as usize)?;
+                    let b = data.positions.get(chunk[1] as usize)?;
+                    let c = data.positions.get(chunk[2] as usize)?;
+                    tris.push([
+                        Vec3::from_array(*a) * auto_fit,
+                        Vec3::from_array(*b) * auto_fit,
+                        Vec3::from_array(*c) * auto_fit,
+                    ]);
+                }
+                return Some(tris);
+            }
+            ComponentData::Collider { shape, .. } => match shape {
+                ColliderShape::Box { half_extents } => {
+                    return Some(cube_triangles(half_extents[0].max(half_extents[1]).max(half_extents[2]) * 2.0));
+                }
+                ColliderShape::Sphere { radius } => {
+                    return Some(sphere_triangles(*radius, 12, 8));
+                }
+                ColliderShape::Capsule { radius, .. } => {
+                    return Some(sphere_triangles(*radius, 12, 8));
+                }
+            },
+            _ => continue,
+        }
+    }
+    None
+}
+
+/// Project triangle vertices to screen space and draw their three edges.
+/// Triangles whose vertices project off-screen (behind the camera) are
+/// skipped. The world transform composes with each triangle vertex.
+pub fn draw_mesh_outline(
+    painter: &egui::Painter,
+    triangles: &[[Vec3; 3]],
+    world_transform: &TransformData,
+    cam_pos: Vec3,
+    cam_target: Vec3,
+    rect: egui::Rect,
+    ortho: bool,
+    ortho_scale: f32,
+    color: egui::Color32,
+    width: f32,
+) {
+    let translation = Vec3::from_array(world_transform.translation);
+    let rotation = Quat::from_euler(
+        bevy::math::EulerRot::XYZ,
+        world_transform.rotation_euler[0],
+        world_transform.rotation_euler[1],
+        world_transform.rotation_euler[2],
+    );
+    let scale = Vec3::from_array(world_transform.scale);
+
+    let stroke = egui::Stroke::new(width, color);
+
+    for tri in triangles {
+        let world: [Vec3; 3] = [
+            translation + rotation * (tri[0] * scale),
+            translation + rotation * (tri[1] * scale),
+            translation + rotation * (tri[2] * scale),
+        ];
+        let projected: [Option<egui::Pos2>; 3] = [
+            project_to_screen(world[0], cam_pos, cam_target, rect, ortho, ortho_scale),
+            project_to_screen(world[1], cam_pos, cam_target, rect, ortho, ortho_scale),
+            project_to_screen(world[2], cam_pos, cam_target, rect, ortho, ortho_scale),
+        ];
+        for &(a, b) in &[(0usize, 1usize), (1, 2), (2, 0)] {
+            if let (Some(pa), Some(pb)) = (projected[a], projected[b]) {
+                painter.line_segment([pa, pb], stroke);
+            }
+        }
+    }
+}
+
+/// Same as [`draw_mesh_outline`], but uses the simpler isometric-ish
+/// projection that the ECS Inspector's mini 3D view uses (it has its own
+/// camera math, no shared `project_to_screen`). The caller supplies a closure
+/// that maps a world-space point to a screen position.
+pub fn draw_mesh_outline_with<P>(
+    painter: &egui::Painter,
+    triangles: &[[Vec3; 3]],
+    world_transform: &TransformData,
+    project: P,
+    color: egui::Color32,
+    width: f32,
+) where
+    P: Fn(Vec3) -> egui::Pos2,
+{
+    let translation = Vec3::from_array(world_transform.translation);
+    let rotation = Quat::from_euler(
+        bevy::math::EulerRot::XYZ,
+        world_transform.rotation_euler[0],
+        world_transform.rotation_euler[1],
+        world_transform.rotation_euler[2],
+    );
+    let scale = Vec3::from_array(world_transform.scale);
+
+    let stroke = egui::Stroke::new(width, color);
+
+    for tri in triangles {
+        let pa = project(translation + rotation * (tri[0] * scale));
+        let pb = project(translation + rotation * (tri[1] * scale));
+        let pc = project(translation + rotation * (tri[2] * scale));
+        painter.line_segment([pa, pb], stroke);
+        painter.line_segment([pb, pc], stroke);
+        painter.line_segment([pc, pa], stroke);
+    }
+}
+
+fn resolve_asset_path(path: &str, project_root: &str) -> String {
+    if path.starts_with('/') || path.contains(":\\") {
+        return path.to_string();
+    }
+    let with_assets = format!("{}/assets/{}", project_root, path);
+    if std::path::Path::new(&with_assets).exists() {
+        with_assets
+    } else {
+        format!("{}/{}", project_root, path)
+    }
+}
+
+fn compute_auto_fit_factor(positions: &[[f32; 3]]) -> f32 {
+    let mut min = [f32::MAX; 3];
+    let mut max = [f32::MIN; 3];
+    for p in positions {
+        for i in 0..3 {
+            min[i] = min[i].min(p[i]);
+            max[i] = max[i].max(p[i]);
+        }
+    }
+    let extent = (max[0] - min[0])
+        .max(max[1] - min[1])
+        .max(max[2] - min[2])
+        .max(0.001);
+    if extent <= 5.0 {
+        1.0
+    } else {
+        2.0 / extent
+    }
+}
+
+/// 12 triangles forming a centered cube of side `size`.
+fn cube_triangles(size: f32) -> Vec<[Vec3; 3]> {
+    let h = size * 0.5;
+    let v = [
+        Vec3::new(-h, -h, -h),
+        Vec3::new(h, -h, -h),
+        Vec3::new(h, h, -h),
+        Vec3::new(-h, h, -h),
+        Vec3::new(-h, -h, h),
+        Vec3::new(h, -h, h),
+        Vec3::new(h, h, h),
+        Vec3::new(-h, h, h),
+    ];
+    let faces = [
+        [0, 1, 2], [0, 2, 3],
+        [4, 6, 5], [4, 7, 6],
+        [0, 4, 5], [0, 5, 1],
+        [2, 6, 7], [2, 7, 3],
+        [0, 3, 7], [0, 7, 4],
+        [1, 5, 6], [1, 6, 2],
+    ];
+    faces
+        .iter()
+        .map(|f| [v[f[0]], v[f[1]], v[f[2]]])
+        .collect()
+}
+
+fn plane_triangles(size: f32) -> Vec<[Vec3; 3]> {
+    let h = size * 0.5;
+    let a = Vec3::new(-h, 0.0, -h);
+    let b = Vec3::new(h, 0.0, -h);
+    let c = Vec3::new(h, 0.0, h);
+    let d = Vec3::new(-h, 0.0, h);
+    vec![[a, b, c], [a, c, d]]
+}
+
+fn sphere_triangles(radius: f32, sectors: usize, stacks: usize) -> Vec<[Vec3; 3]> {
+    use std::f32::consts::PI;
+    let mut verts = Vec::with_capacity((stacks + 1) * (sectors + 1));
+    for i in 0..=stacks {
+        let phi = PI / 2.0 - (i as f32) * PI / stacks as f32;
+        let xy = radius * phi.cos();
+        let z = radius * phi.sin();
+        for j in 0..=sectors {
+            let theta = (j as f32) * 2.0 * PI / sectors as f32;
+            verts.push(Vec3::new(xy * theta.cos(), z, xy * theta.sin()));
+        }
+    }
+    let row = sectors + 1;
+    let mut tris = Vec::new();
+    for i in 0..stacks {
+        for j in 0..sectors {
+            let a = i * row + j;
+            let b = a + row;
+            tris.push([verts[a], verts[a + 1], verts[b]]);
+            tris.push([verts[a + 1], verts[b + 1], verts[b]]);
+        }
+    }
+    tris
+}

--- a/berrycode/src/app/scene_editor/mesh_outline.rs
+++ b/berrycode/src/app/scene_editor/mesh_outline.rs
@@ -13,10 +13,7 @@ use bevy::math::{Quat, Vec3};
 /// data-only components, etc.) so the caller can fall back to a default
 /// gizmo. Paths inside `MeshFromFile` are resolved relative to
 /// `<project_root>/assets/`.
-pub fn triangles_for_entity(
-    entity: &SceneEntity,
-    project_root: &str,
-) -> Option<Vec<[Vec3; 3]>> {
+pub fn triangles_for_entity(entity: &SceneEntity, project_root: &str) -> Option<Vec<[Vec3; 3]>> {
     for c in &entity.components {
         match c {
             ComponentData::MeshCube { size, .. } => {
@@ -50,7 +47,9 @@ pub fn triangles_for_entity(
             }
             ComponentData::Collider { shape, .. } => match shape {
                 ColliderShape::Box { half_extents } => {
-                    return Some(cube_triangles(half_extents[0].max(half_extents[1]).max(half_extents[2]) * 2.0));
+                    return Some(cube_triangles(
+                        half_extents[0].max(half_extents[1]).max(half_extents[2]) * 2.0,
+                    ));
                 }
                 ColliderShape::Sphere { radius } => {
                     return Some(sphere_triangles(*radius, 12, 8));
@@ -191,17 +190,20 @@ fn cube_triangles(size: f32) -> Vec<[Vec3; 3]> {
         Vec3::new(-h, h, h),
     ];
     let faces = [
-        [0, 1, 2], [0, 2, 3],
-        [4, 6, 5], [4, 7, 6],
-        [0, 4, 5], [0, 5, 1],
-        [2, 6, 7], [2, 7, 3],
-        [0, 3, 7], [0, 7, 4],
-        [1, 5, 6], [1, 6, 2],
+        [0, 1, 2],
+        [0, 2, 3],
+        [4, 6, 5],
+        [4, 7, 6],
+        [0, 4, 5],
+        [0, 5, 1],
+        [2, 6, 7],
+        [2, 7, 3],
+        [0, 3, 7],
+        [0, 7, 4],
+        [1, 5, 6],
+        [1, 6, 2],
     ];
-    faces
-        .iter()
-        .map(|f| [v[f[0]], v[f[1]], v[f[2]]])
-        .collect()
+    faces.iter().map(|f| [v[f[0]], v[f[1]], v[f[2]]]).collect()
 }
 
 fn plane_triangles(size: f32) -> Vec<[Vec3; 3]> {

--- a/berrycode/src/app/scene_editor/mod.rs
+++ b/berrycode/src/app/scene_editor/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod humanoid_avatar;
 pub(crate) mod inspector;
 pub(crate) mod live_sync;
 pub(crate) mod material_preview;
+pub(crate) mod mesh_outline;
 pub(crate) mod model;
 pub(crate) mod navmesh;
 pub(crate) mod particle_preview;

--- a/berrycode/src/app/scene_editor/scene_view.rs
+++ b/berrycode/src/app/scene_editor/scene_view.rs
@@ -906,11 +906,32 @@ impl BerryCodeApp {
             }
         }
 
-        // Selection wireframe AABB overlay for ALL selected entities.
+        // Selection mesh-outline overlay for ALL selected entities. Falls
+        // back to the AABB wireframe for non-mesh components (lights,
+        // cameras, etc.) so users still get *some* selection feedback.
         for &sel_id in &self.scene_model.selected_ids.clone() {
             if let Some(entity) = self.scene_model.entities.get(&sel_id) {
                 let world_t = self.scene_model.compute_world_transform(sel_id);
-                if let Some((amin, amax)) = aabb_for_entity(entity, &world_t) {
+                let tris = crate::app::scene_editor::mesh_outline::triangles_for_entity(
+                    entity,
+                    &self.root_path,
+                );
+                if let Some(triangles) = tris {
+                    crate::app::scene_editor::mesh_outline::draw_mesh_outline(
+                        ui.painter(),
+                        &triangles,
+                        &world_t,
+                        cam_pos,
+                        orbit_target,
+                        rect,
+                        ortho,
+                        ortho_scale,
+                        egui::Color32::YELLOW,
+                        1.0,
+                    );
+                } else if let Some((amin, amax)) =
+                    aabb_for_entity(entity, &world_t, &self.root_path)
+                {
                     draw_wireframe_aabb(
                         ui.painter(),
                         amin,
@@ -1003,7 +1024,7 @@ impl BerryCodeApp {
                         continue;
                     }
                     let world_t = self.scene_model.compute_world_transform(*id);
-                    if let Some((amin, amax)) = aabb_for_entity(entity, &world_t) {
+                    if let Some((amin, amax)) = aabb_for_entity(entity, &world_t, &self.root_path) {
                         if let Some(t) = ray_aabb_hit(origin, dir, amin, amax) {
                             if closest.map_or(true, |(_, ct)| t < ct) {
                                 closest = Some((*id, t));

--- a/berrycode/src/bevy_plugin.rs
+++ b/berrycode/src/bevy_plugin.rs
@@ -8,7 +8,8 @@ use crate::app::preview_3d::{
     ModelPreviewScene,
 };
 use crate::app::scene_editor::bevy_render::{
-    setup_scene_editor_render, update_scene_editor_camera, SceneEditorRender,
+    propagate_scene_editor_render_layers, setup_scene_editor_render, update_scene_editor_camera,
+    SceneEditorRender,
 };
 use crate::app::scene_editor::bevy_sync::sync_scene_to_bevy;
 use crate::app::scene_editor::material_preview::{
@@ -59,6 +60,10 @@ impl Plugin for BerryCodePlugin {
             )
             .add_systems(Update, update_scene_editor_camera)
             .add_systems(Update, sync_scene_to_bevy)
+            .add_systems(
+                Update,
+                propagate_scene_editor_render_layers.after(sync_scene_to_bevy),
+            )
             .add_systems(Update, update_material_preview);
     }
 }


### PR DESCRIPTION
## Summary

- Replace manual GLB parsing in `bevy_sync.rs` (which extracted only the first primitive of the first mesh) with Bevy's `SceneRoot` pipeline, so models load through `AssetServer` + `GltfAssetLabel` and preserve multi-mesh structure, materials, and skeletal data.
- Add `propagate_scene_editor_render_layers` to push `RenderLayers::layer(2)` to children spawned asynchronously by `SceneRoot`. Without this, GLTF child meshes never reach the editor's off-screen camera.
- New `stage_asset_for_loading` helper copies user-picked files into `assets/_preview/` because Bevy's default `AssetPlugin` can't resolve `file://` URLs. Used by `MeshFromFile`, `SkinnedMesh`, and `LodGroup`.
- Slim `GltfMeshData` to just `positions` — the only field consumed by `gizmo.rs` / `codegen.rs` after removing the manual loader.

Closes #2

## Test plan

- [x] \`cargo check\` clean (only pre-existing deprecation warnings)
- [x] \`cargo test --lib\` — 476/476 pass
- [ ] Manual: open Scene Editor, add a MeshFromFile entity pointing to a multi-mesh GLB (e.g. fox.glb), verify all meshes render
- [ ] Manual: same with a SkinnedMesh GLB and a LodGroup setup
- [ ] Manual: verify the propagation system catches GLTF children spawned across multiple frames