### PR TITLE
fix(preview): camera order, ambient light layer, orbit distance (partial #1)

### DIFF
--- a/berrycode/src/app/mod.rs
+++ b/berrycode/src/app/mod.rs
@@ -2313,7 +2313,11 @@ pub fn berry_ui_system(
             }
             preview_scene.orbit_yaw = orbit_yaw;
             preview_scene.orbit_pitch = orbit_pitch;
-            preview_scene.orbit_distance = orbit_zoom * 3.0;
+            // The previous multiplier of 3.0 placed the camera *inside* the
+            // bounding box of typical GLB models (e.g. fox.glb ~6 units),
+            // which combined with backface culling produced an empty render
+            // target. 10.0 keeps the default view comfortably outside.
+            preview_scene.orbit_distance = orbit_zoom * 10.0;
 
             if let Some(handle) = preview_scene.render_target.clone() {
                 let texture_id = egui_ctx.add_image(bevy_egui::EguiTextureHandle::Strong(handle));

--- a/berrycode/src/app/model_preview.rs
+++ b/berrycode/src/app/model_preview.rs
@@ -1102,7 +1102,12 @@ impl BerryCodeApp {
             .next()
             .unwrap_or("")
             .to_lowercase();
-        if (ext == "glb" || ext == "gltf") && tab.gpu_preview_texture_id.is_some() {
+        // The GPU preview path is wired up but its render target still
+        // arrives black on macOS — the bevy_egui ↔ render-graph interaction
+        // is not yet sorted out (see Issue #1). The `false &&` keeps users
+        // on the CPU wireframe fallback (which works) until that's fixed,
+        // even though `gpu_preview_texture_id` is populated.
+        if false && (ext == "glb" || ext == "gltf") && tab.gpu_preview_texture_id.is_some() {
             let texture_id = tab.gpu_preview_texture_id.unwrap();
 
             // Metadata header

--- a/berrycode/src/app/model_preview.rs
+++ b/berrycode/src/app/model_preview.rs
@@ -1102,7 +1102,7 @@ impl BerryCodeApp {
             .next()
             .unwrap_or("")
             .to_lowercase();
-        if false && (ext == "glb" || ext == "gltf") && tab.gpu_preview_texture_id.is_some() {
+        if (ext == "glb" || ext == "gltf") && tab.gpu_preview_texture_id.is_some() {
             let texture_id = tab.gpu_preview_texture_id.unwrap();
 
             // Metadata header

--- a/berrycode/src/app/preview_3d.rs
+++ b/berrycode/src/app/preview_3d.rs
@@ -61,13 +61,17 @@ pub fn setup_preview_render_target(
 
     let image_handle = images.add(image);
 
-    // Spawn preview camera targeting the render texture
-    // Matches Scene Editor pattern (bevy_render.rs) which is known to work.
+    // Spawn preview camera targeting the render texture.
+    // `order: -1` is intentionally distinct from the scene editor camera
+    // (`order: -2` in `bevy_render.rs`) and the material preview camera
+    // (`order: -3`). When two off-screen cameras share an order Bevy's
+    // render order is undefined, which manifested as the preview render
+    // target staying black (#1).
     commands.spawn((
         Camera3d::default(),
         Camera {
             clear_color: ClearColorConfig::Custom(Color::srgba(0.098, 0.102, 0.11, 1.0)),
-            order: -2,
+            order: -1,
             ..default()
         },
         bevy::camera::RenderTarget::Image(image_handle.clone().into()),
@@ -94,12 +98,16 @@ pub fn setup_preview_render_target(
         RenderLayers::layer(1),
     ));
 
-    // Ambient light
-    commands.spawn(AmbientLight {
-        color: Color::WHITE,
-        brightness: 300.0,
-        affects_lightmapped_meshes: false,
-    });
+    // Ambient light, scoped to layer 1 so it lifts the preview scene without
+    // bleeding into the scene editor or material preview viewports.
+    commands.spawn((
+        AmbientLight {
+            color: Color::WHITE,
+            brightness: 600.0,
+            affects_lightmapped_meshes: false,
+        },
+        RenderLayers::layer(1),
+    ));
 
     preview.render_target = Some(image_handle);
     preview.preview_width = width;


### PR DESCRIPTION
## Summary

Three small preview-camera improvements that don't fix Issue #1 outright but stop us from making it worse:

1. Use a unique camera order (\`-1\`) for the preview camera. The scene editor camera is already at \`-2\` and material preview at \`-3\`; with two off-screen cameras sharing the same order, render order is undefined.
2. Scope the preview ambient light to \`RenderLayers::layer(1)\` and bump brightness so models don't render into a featureless dark.
3. Bump the orbit-distance multiplier from 3 to 10. With the manual GLB auto-scale removed in #2, the previous distance placed the camera inside the bounding box of typical models (fox.glb ~6 units), producing an empty render target after backface culling.

## Why this does NOT close #1

Manual UI verification showed the GPU render target still arrives black on macOS even with these fixes. The root cause is deeper in the bevy_egui ↔ render-graph interaction (the original Issue notes "Standalone Bevy app + SceneRoot + no bevy_egui works"). An earlier revision of this PR also dropped the \`if false &&\` kill switch in \`model_preview.rs\` to enable the GPU path, but that wiped out the CPU wireframe fallback too — leaving users with an empty preview pane. The kill switch is restored in the latest commit so the working CPU fallback stays visible while #1 stays open.

## Test plan

- [x] \`cargo check\` clean
- [x] Manual: open fox.glb — CPU wireframe preview still renders (regression check)
- [ ] Issue #1 (actual GPU PBR rendering) intentionally left for follow-up