### PR TITLE
fix: terminal CJK width, paste, and IME commit handling (#3)

### DIFF
--- a/berrycode/src/app/terminal.rs
+++ b/berrycode/src/app/terminal.rs
@@ -71,6 +71,13 @@ impl BerryCodeApp {
                                 let mut run_bold = false;
 
                                 for (col_idx, cell) in line.iter().enumerate() {
+                                    // Continuation slot of a wide CJK glyph
+                                    // — leading cell already carries the char.
+                                    if cell.ch
+                                        == super::terminal_emulator::WIDE_CONTINUATION
+                                    {
+                                        continue;
+                                    }
                                     let same = cell.fg == run_fg && cell.bold == run_bold;
                                     if !same && !run_text.is_empty() {
                                         let mut rt = egui::RichText::new(&run_text)
@@ -437,56 +444,86 @@ impl BerryCodeApp {
                 for (row, line) in visible.iter().enumerate() {
                     let y = origin.y + row as f32 * cell_h;
 
-                    // Paint by style runs (batched for performance)
+                    // Paint by style runs (batched for performance). `run_cells`
+                    // tracks how many grid columns the run covers, which differs
+                    // from `run_text.len()` whenever the run contains a CJK
+                    // double-width glyph (advances 2 columns but is 1 char).
                     let mut run_start_col = 0;
                     let mut run_text = String::new();
+                    let mut run_cells: usize = 0;
                     let mut run_fg = TERM_FG;
                     let mut run_bg = TERM_BG;
                     let mut run_bold = false;
                     let mut run_underline = false;
 
+                    let flush =
+                        |painter: &egui::Painter,
+                         run_start_col: usize,
+                         run_text: &str,
+                         run_cells: usize,
+                         run_fg: egui::Color32,
+                         run_bg: egui::Color32,
+                         run_bold: bool,
+                         run_underline: bool| {
+                            if run_text.is_empty() {
+                                return;
+                            }
+                            let x = origin.x + run_start_col as f32 * cell_w;
+                            let run_w = run_cells as f32 * cell_w;
+                            if run_bg != TERM_BG {
+                                let bg_rect = egui::Rect::from_min_size(
+                                    egui::pos2(x, y),
+                                    egui::vec2(run_w, cell_h),
+                                );
+                                painter.rect_filled(bg_rect, 0.0, run_bg);
+                            }
+                            let text_pos = egui::pos2(x, y + 1.0);
+                            let fid = if run_bold {
+                                egui::FontId::monospace(font_size)
+                            } else {
+                                egui::FontId::monospace(font_size)
+                            };
+                            painter.text(
+                                text_pos,
+                                egui::Align2::LEFT_TOP,
+                                run_text,
+                                fid,
+                                run_fg,
+                            );
+                            if run_underline {
+                                let ul_y = y + cell_h - 2.0;
+                                painter.line_segment(
+                                    [egui::pos2(x, ul_y), egui::pos2(x + run_w, ul_y)],
+                                    egui::Stroke::new(1.0, run_fg),
+                                );
+                            }
+                        };
+
                     for col in 0..=grid.cols.min(line.len()) {
                         let at_end = col >= grid.cols.min(line.len());
 
                         if at_end {
-                            // Flush remaining run
-                            if !run_text.is_empty() {
-                                let x = origin.x + run_start_col as f32 * cell_w;
-                                if run_bg != TERM_BG {
-                                    let bg_rect = egui::Rect::from_min_size(
-                                        egui::pos2(x, y),
-                                        egui::vec2(run_text.len() as f32 * cell_w, cell_h),
-                                    );
-                                    painter.rect_filled(bg_rect, 0.0, run_bg);
-                                }
-                                let text_pos = egui::pos2(x, y + 1.0);
-                                let fid = if run_bold {
-                                    egui::FontId::monospace(font_size)
-                                } else {
-                                    font_id.clone()
-                                };
-                                painter.text(
-                                    text_pos,
-                                    egui::Align2::LEFT_TOP,
-                                    &run_text,
-                                    fid,
-                                    run_fg,
-                                );
-                                if run_underline {
-                                    let ul_y = y + cell_h - 2.0;
-                                    painter.line_segment(
-                                        [
-                                            egui::pos2(x, ul_y),
-                                            egui::pos2(x + run_text.len() as f32 * cell_w, ul_y),
-                                        ],
-                                        egui::Stroke::new(1.0, run_fg),
-                                    );
-                                }
-                            }
+                            flush(
+                                &painter,
+                                run_start_col,
+                                &run_text,
+                                run_cells,
+                                run_fg,
+                                run_bg,
+                                run_bold,
+                                run_underline,
+                            );
                             break;
                         }
 
                         let cell = &line[col];
+
+                        // Skip continuation slot of the previous wide glyph;
+                        // it has already been "consumed" by the leading cell.
+                        if cell.ch == super::terminal_emulator::WIDE_CONTINUATION {
+                            continue;
+                        }
+
                         let in_selection = tab
                             .selection
                             .as_ref()
@@ -499,6 +536,10 @@ impl BerryCodeApp {
                             (cell.fg, cell.bg)
                         };
 
+                        let cell_width = unicode_width::UnicodeWidthChar::width(cell.ch)
+                            .unwrap_or(1)
+                            .max(1);
+
                         let same_style = !run_text.is_empty()
                             && cell_fg == run_fg
                             && cell_bg == run_bg
@@ -507,50 +548,26 @@ impl BerryCodeApp {
 
                         if same_style {
                             run_text.push(cell.ch);
+                            run_cells += cell_width;
                         } else {
-                            // Flush previous run
-                            if !run_text.is_empty() {
-                                let x = origin.x + run_start_col as f32 * cell_w;
-                                if run_bg != TERM_BG {
-                                    let bg_rect = egui::Rect::from_min_size(
-                                        egui::pos2(x, y),
-                                        egui::vec2(run_text.len() as f32 * cell_w, cell_h),
-                                    );
-                                    painter.rect_filled(bg_rect, 0.0, run_bg);
-                                }
-                                let text_pos = egui::pos2(x, y + 1.0);
-                                let fid = if run_bold {
-                                    egui::FontId::monospace(font_size)
-                                } else {
-                                    font_id.clone()
-                                };
-                                painter.text(
-                                    text_pos,
-                                    egui::Align2::LEFT_TOP,
-                                    &run_text,
-                                    fid,
-                                    run_fg,
-                                );
-                                if run_underline {
-                                    let ul_y = y + cell_h - 2.0;
-                                    painter.line_segment(
-                                        [
-                                            egui::pos2(x, ul_y),
-                                            egui::pos2(x + run_text.len() as f32 * cell_w, ul_y),
-                                        ],
-                                        egui::Stroke::new(1.0, run_fg),
-                                    );
-                                }
-                                run_text.clear();
-                            }
-
-                            // Start new run
+                            flush(
+                                &painter,
+                                run_start_col,
+                                &run_text,
+                                run_cells,
+                                run_fg,
+                                run_bg,
+                                run_bold,
+                                run_underline,
+                            );
+                            run_text.clear();
                             run_start_col = col;
                             run_fg = cell_fg;
                             run_bg = cell_bg;
                             run_bold = cell.bold;
                             run_underline = cell.underline;
                             run_text.push(cell.ch);
+                            run_cells = cell_width;
                         }
                     }
                 }
@@ -577,7 +594,9 @@ impl BerryCodeApp {
                         && grid.cursor_col < grid.cells[grid.cursor_row].len()
                     {
                         let ch = grid.cells[grid.cursor_row][grid.cursor_col].ch;
-                        if ch != ' ' {
+                        if ch != ' '
+                            && ch != super::terminal_emulator::WIDE_CONTINUATION
+                        {
                             painter.text(
                                 egui::pos2(cx, cy + 1.0),
                                 egui::Align2::LEFT_TOP,
@@ -664,9 +683,21 @@ impl BerryCodeApp {
         for event in &events {
             match event {
                 egui::Event::Text(text) => {
-                    // Normal text input (not consumed by modifiers)
+                    // Normal text input (not consumed by modifiers).
+                    // egui converts most IME-committed CJK input into Text
+                    // events, so this path also handles 日本語 / 中文 input.
                     tab.write_to_pty(text.as_bytes());
                     had_input = true;
+                }
+                egui::Event::Ime(ime_event) => {
+                    // Some platforms (notably macOS) deliver the committed
+                    // IME string as a separate Ime::Commit instead of Text.
+                    // Forward it so Japanese / Chinese / Korean characters
+                    // typed via IME reach the PTY in either path.
+                    if let egui::ImeEvent::Commit(text) = ime_event {
+                        tab.write_to_pty(text.as_bytes());
+                        had_input = true;
+                    }
                 }
                 egui::Event::Key {
                     key,

--- a/berrycode/src/app/terminal.rs
+++ b/berrycode/src/app/terminal.rs
@@ -73,9 +73,7 @@ impl BerryCodeApp {
                                 for (col_idx, cell) in line.iter().enumerate() {
                                     // Continuation slot of a wide CJK glyph
                                     // — leading cell already carries the char.
-                                    if cell.ch
-                                        == super::terminal_emulator::WIDE_CONTINUATION
-                                    {
+                                    if cell.ch == super::terminal_emulator::WIDE_CONTINUATION {
                                         continue;
                                     }
                                     let same = cell.fg == run_fg && cell.bold == run_bold;
@@ -456,48 +454,41 @@ impl BerryCodeApp {
                     let mut run_bold = false;
                     let mut run_underline = false;
 
-                    let flush =
-                        |painter: &egui::Painter,
-                         run_start_col: usize,
-                         run_text: &str,
-                         run_cells: usize,
-                         run_fg: egui::Color32,
-                         run_bg: egui::Color32,
-                         run_bold: bool,
-                         run_underline: bool| {
-                            if run_text.is_empty() {
-                                return;
-                            }
-                            let x = origin.x + run_start_col as f32 * cell_w;
-                            let run_w = run_cells as f32 * cell_w;
-                            if run_bg != TERM_BG {
-                                let bg_rect = egui::Rect::from_min_size(
-                                    egui::pos2(x, y),
-                                    egui::vec2(run_w, cell_h),
-                                );
-                                painter.rect_filled(bg_rect, 0.0, run_bg);
-                            }
-                            let text_pos = egui::pos2(x, y + 1.0);
-                            let fid = if run_bold {
-                                egui::FontId::monospace(font_size)
-                            } else {
-                                egui::FontId::monospace(font_size)
-                            };
-                            painter.text(
-                                text_pos,
-                                egui::Align2::LEFT_TOP,
-                                run_text,
-                                fid,
-                                run_fg,
+                    let flush = |painter: &egui::Painter,
+                                 run_start_col: usize,
+                                 run_text: &str,
+                                 run_cells: usize,
+                                 run_fg: egui::Color32,
+                                 run_bg: egui::Color32,
+                                 run_bold: bool,
+                                 run_underline: bool| {
+                        if run_text.is_empty() {
+                            return;
+                        }
+                        let x = origin.x + run_start_col as f32 * cell_w;
+                        let run_w = run_cells as f32 * cell_w;
+                        if run_bg != TERM_BG {
+                            let bg_rect = egui::Rect::from_min_size(
+                                egui::pos2(x, y),
+                                egui::vec2(run_w, cell_h),
                             );
-                            if run_underline {
-                                let ul_y = y + cell_h - 2.0;
-                                painter.line_segment(
-                                    [egui::pos2(x, ul_y), egui::pos2(x + run_w, ul_y)],
-                                    egui::Stroke::new(1.0, run_fg),
-                                );
-                            }
+                            painter.rect_filled(bg_rect, 0.0, run_bg);
+                        }
+                        let text_pos = egui::pos2(x, y + 1.0);
+                        let fid = if run_bold {
+                            egui::FontId::monospace(font_size)
+                        } else {
+                            egui::FontId::monospace(font_size)
                         };
+                        painter.text(text_pos, egui::Align2::LEFT_TOP, run_text, fid, run_fg);
+                        if run_underline {
+                            let ul_y = y + cell_h - 2.0;
+                            painter.line_segment(
+                                [egui::pos2(x, ul_y), egui::pos2(x + run_w, ul_y)],
+                                egui::Stroke::new(1.0, run_fg),
+                            );
+                        }
+                    };
 
                     for col in 0..=grid.cols.min(line.len()) {
                         let at_end = col >= grid.cols.min(line.len());
@@ -594,9 +585,7 @@ impl BerryCodeApp {
                         && grid.cursor_col < grid.cells[grid.cursor_row].len()
                     {
                         let ch = grid.cells[grid.cursor_row][grid.cursor_col].ch;
-                        if ch != ' '
-                            && ch != super::terminal_emulator::WIDE_CONTINUATION
-                        {
+                        if ch != ' ' && ch != super::terminal_emulator::WIDE_CONTINUATION {
                             painter.text(
                                 egui::pos2(cx, cy + 1.0),
                                 egui::Align2::LEFT_TOP,

--- a/berrycode/src/app/terminal_emulator.rs
+++ b/berrycode/src/app/terminal_emulator.rs
@@ -11,6 +11,14 @@ use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use unicode_width::UnicodeWidthChar;
+
+/// Sentinel character stored in the cell immediately after a double-width
+/// (e.g. CJK) glyph. The renderer treats `'\0'` cells as continuation slots
+/// and skips them, while cursor / paste / selection logic uses cell columns
+/// that include the continuation, so a 2-column "あ" advances the cursor
+/// by 2 like a real terminal does.
+pub const WIDE_CONTINUATION: char = '\0';
 
 // ═══════════════════════════════════════════════════════════════════
 // Constants — iTerm2 Default Dark theme colors
@@ -181,7 +189,20 @@ impl TerminalGrid {
     }
 
     fn put_char(&mut self, ch: char) {
+        // Width 0 (combining marks) collapses into the previous cell — we
+        // treat it as 1 here for simplicity. Width 2 means CJK / fullwidth
+        // and consumes two grid columns.
+        let width = ch.width().unwrap_or(1).max(1);
+
         if self.wrap_next && self.auto_wrap {
+            self.cursor_col = 0;
+            self.newline();
+            self.wrap_next = false;
+        }
+
+        // A double-width glyph that would split across the right edge wraps
+        // to the next line first, matching xterm behavior.
+        if width == 2 && self.cursor_col + 1 >= self.cols && self.auto_wrap {
             self.cursor_col = 0;
             self.newline();
             self.wrap_next = false;
@@ -201,12 +222,22 @@ impl TerminalGrid {
                 underline: self.underline,
                 inverse: false,
             };
+            if width == 2 && self.cursor_col + 1 < self.cols {
+                self.cells[self.cursor_row][self.cursor_col + 1] = Cell {
+                    ch: WIDE_CONTINUATION,
+                    fg,
+                    bg,
+                    bold: self.bold,
+                    underline: self.underline,
+                    inverse: false,
+                };
+            }
         }
 
-        if self.cursor_col + 1 >= self.cols {
+        if self.cursor_col + width >= self.cols {
             self.wrap_next = true;
         } else {
-            self.cursor_col += 1;
+            self.cursor_col += width;
         }
     }
 
@@ -1060,7 +1091,13 @@ impl TerminalTab {
             };
 
             for col in col_start..=col_end {
-                text.push(grid.cells[row][col].ch);
+                let ch = grid.cells[row][col].ch;
+                // Skip continuation cells of double-width glyphs so a
+                // copied "あ" doesn't turn into "あ\0".
+                if ch == WIDE_CONTINUATION {
+                    continue;
+                }
+                text.push(ch);
             }
             // Trim trailing spaces on each line
             let trimmed = text.trim_end().len();


### PR DESCRIPTION
## Summary

The terminal grid used to advance the cursor by exactly one cell per character, which broke whenever a double-width CJK glyph entered the buffer (typed via IME or pasted). The grid's column tracking diverged from the visual layout produced by egui's text shaper, manifesting as cursor misalignment and overlapping glyphs after paste.

### Grid changes (\`terminal_emulator.rs\`)

- \`put_char\` now consults \`unicode_width::UnicodeWidthChar\`. A width-2 glyph occupies the leading cell plus a \`WIDE_CONTINUATION\` (\`'\\0'\`) sentinel in the next cell, and the cursor advances by 2.
- Auto-wrap kicks in early when a wide glyph wouldn't fit on the current line, matching xterm.
- \`get_selected_text\` skips continuation cells so copied text is the user-visible string (\"あ\", not \"あ\\0\").

### Renderer changes (\`terminal.rs\`)

- The fullscreen and sidebar grid renderers skip continuation cells.
- Style-run flushing now tracks \`run_cells\` separately from \`run_text.len()\` so background rectangles and underline strokes cover the right number of grid columns when a run includes CJK.
- The cursor overlay no longer tries to paint the \`'\\0'\` sentinel.

### IME input

- \`Event::Ime(ImeEvent::Commit(text))\` is now forwarded to the PTY in addition to \`Event::Text\`. macOS in particular delivers committed CJK strings as \`Ime::Commit\`, so this closes the path where Japanese input typed via IME never reached the shell.

### Follow-up not in this PR

In-progress IME preedit display (showing candidate text inline) still isn't shown — that requires wiring \`egui::Output::ime\` against a focusable terminal response.

Closes #3

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo test --lib\` — 476/476 pass
- [ ] Manual: paste a string containing 日本語 — cursor and following text remain aligned
- [ ] Manual: type Japanese via macOS IME — committed characters reach the shell
- [ ] Manual: select CJK text and copy — clipboard contains exactly the visible characters