### PR TITLE
fix: terminal IME preedit + CJK cursor alignment + editor IME visibility

### DIFF
--- a/berrycode/src/app/editor.rs
+++ b/berrycode/src/app/editor.rs
@@ -1318,9 +1318,13 @@ impl BerryCodeApp {
                     }
 
                     // === Compute cursor line for inline blame ===
+                    // egui's `CCursor::index` is a *char* index, not a byte
+                    // index. Slicing `text[..idx]` directly panics whenever
+                    // the cursor sits past a multi-byte glyph (e.g. CJK), so
+                    // count newlines via the char iterator instead.
                     let cursor_line_for_blame: Option<usize> = output.cursor_range.map(|cr| {
                         let idx = cr.primary.index;
-                        text[..idx.min(text.len())].matches('\n').count()
+                        text.chars().take(idx).filter(|c| *c == '\n').count()
                     });
 
                     // Store text back into cache (avoids re-conversion next frame)

--- a/berrycode/src/app/mod.rs
+++ b/berrycode/src/app/mod.rs
@@ -686,7 +686,10 @@ impl BerryCodeApp {
         let bg_input = egui::Color32::from_rgb(50, 52, 56); // input fields
         let bg_hover = egui::Color32::from_rgb(55, 57, 61); // hover state
         let bg_active = egui::Color32::from_rgb(65, 68, 74); // active/pressed
-        let bg_selected = egui::Color32::from_rgb(38, 79, 140); // brighter blue selection
+                                                             // Selection bg uses RGBA with alpha so the underlying text remains
+                                                             // legible during IME preedit (egui paints selection over the glyphs).
+                                                             // Premultiplied alpha: ~30% opacity = (rgb * 0.3, alpha 76).
+        let bg_selected = egui::Color32::from_rgba_premultiplied(11, 24, 42, 76);
         let border = egui::Color32::from_rgb(60, 63, 68); // borders
         let border_focus = egui::Color32::from_rgb(75, 110, 175); // focused border (accent)
         let text = egui::Color32::from_rgb(205, 207, 213); // primary text
@@ -710,9 +713,12 @@ impl BerryCodeApp {
         visuals.window_corner_radius = egui::CornerRadius::same(8);
         visuals.menu_corner_radius = egui::CornerRadius::same(6);
 
-        // Selection
+        // Selection — `selection.stroke.color` is misleadingly named: egui
+        // uses it to *override* the glyph color of the selected text, so it
+        // must be visible (using TRANSPARENT here makes selected text — and
+        // IME preedit text — invisible).
         visuals.selection.bg_fill = bg_selected;
-        visuals.selection.stroke = egui::Stroke::new(0.0, egui::Color32::TRANSPARENT);
+        visuals.selection.stroke = egui::Stroke::new(0.0, text);
 
         // Text cursor
         visuals.text_cursor.stroke.color = egui::Color32::from_rgb(180, 190, 220);
@@ -1840,8 +1846,9 @@ pub fn setup_egui_fonts_and_style(
     visuals.widgets.inactive.bg_fill = egui::Color32::from_rgb(25, 26, 28);
     visuals.widgets.hovered.bg_fill = egui::Color32::from_rgb(45, 47, 50);
     visuals.widgets.active.bg_fill = egui::Color32::from_rgb(60, 63, 65);
-    visuals.selection.bg_fill = egui::Color32::from_rgb(38, 79, 140);
-    visuals.selection.stroke = egui::Stroke::new(0.0, egui::Color32::TRANSPARENT);
+    visuals.selection.bg_fill = egui::Color32::from_rgba_premultiplied(11, 24, 42, 76);
+    // `selection.stroke.color` is the text color override for selected glyphs.
+    visuals.selection.stroke = egui::Stroke::new(0.0, egui::Color32::from_rgb(212, 212, 212));
     visuals.code_bg_color = egui::Color32::from_rgb(25, 26, 28);
     ctx.set_visuals(visuals);
 

--- a/berrycode/src/app/terminal.rs
+++ b/berrycode/src/app/terminal.rs
@@ -400,9 +400,12 @@ impl BerryCodeApp {
     fn render_terminal_grid(&mut self, ui: &mut egui::Ui) {
         let available = ui.available_rect_before_wrap();
 
-        // Calculate cell dimensions from monospace font
+        // Calculate cell dimensions from monospace font.
+        // The 0.575 ratio is tuned so CJK glyphs (rendered in 2 cells) leave
+        // only a small visual gap to neighbouring chars without making ASCII
+        // text feel cramped.
         let font_size = 13.5_f32;
-        let cell_w = font_size * 0.6; // approximate monospace char width
+        let cell_w = font_size * 0.575;
         let cell_h = font_size * 1.4;
         let padding_x = 6.0;
         let padding_y = 4.0;
@@ -422,6 +425,52 @@ impl BerryCodeApp {
         let (response, painter) =
             ui.allocate_painter(available.size(), egui::Sense::click_and_drag());
         let rect = response.rect;
+
+        // Focus handling: any pointer press inside the terminal area moves
+        // focus here. `response.clicked()` only fires on press+release on
+        // the same widget, which selection-drags don't satisfy, so use
+        // pointer state directly. We also auto-focus on first frame so
+        // typing works without needing to click first.
+        let (any_pressed, interact_pos) =
+            ui.input(|i| (i.pointer.any_pressed(), i.pointer.interact_pos()));
+        let pointer_pressed_in_rect =
+            any_pressed && interact_pos.map_or(false, |p| rect.contains(p));
+        if pointer_pressed_in_rect || response.clicked() || response.is_pointer_button_down_on() {
+            response.request_focus();
+        }
+
+        // Auto-focus when no other widget holds focus (e.g. right after
+        // switching to the fullscreen terminal panel). Without this, users
+        // have to click inside the grid before IME activates, which is
+        // surprising for a panel that's expected to receive typing
+        // immediately.
+        let any_focused = ui.memory(|m| m.focused().is_some());
+        if !any_focused && !response.has_focus() {
+            response.request_focus();
+        }
+        let focused = response.has_focus();
+
+        // Only advertise an IME area when the terminal has focus; otherwise
+        // every keystroke (including English) would route through the IME
+        // composition pipeline and stall normal typing.
+        if focused {
+            let cursor_rect = if let Some(tab) = self.terminal.active_tab() {
+                tab.grid
+                    .lock()
+                    .ok()
+                    .map(|g| {
+                        let cx = rect.left() + padding_x + g.cursor_col as f32 * cell_w;
+                        let cy = rect.top() + padding_y + g.cursor_row as f32 * cell_h;
+                        egui::Rect::from_min_size(egui::pos2(cx, cy), egui::vec2(cell_w, cell_h))
+                    })
+                    .unwrap_or(rect)
+            } else {
+                rect
+            };
+            ui.ctx().output_mut(|o| {
+                o.ime = Some(egui::output::IMEOutput { rect, cursor_rect });
+            });
+        }
 
         // Fill background
         painter.rect_filled(rect, 0.0, TERM_BG);
@@ -474,13 +523,47 @@ impl BerryCodeApp {
                             );
                             painter.rect_filled(bg_rect, 0.0, run_bg);
                         }
-                        let text_pos = egui::pos2(x, y + 1.0);
                         let fid = if run_bold {
                             egui::FontId::monospace(font_size)
                         } else {
                             egui::FontId::monospace(font_size)
                         };
-                        painter.text(text_pos, egui::Align2::LEFT_TOP, run_text, fid, run_fg);
+                        // The Japanese font we register as a Monospace fallback
+                        // is proportional, so CJK glyphs don't advance by exactly
+                        // 2 grid cells. Drawing the run with one `painter.text`
+                        // call accumulates that error and the cursor drifts past
+                        // the visible text. Place each char at its exact column
+                        // instead so grid coords stay aligned with pixels.
+                        let has_wide = run_text
+                            .chars()
+                            .any(|c| unicode_width::UnicodeWidthChar::width(c).unwrap_or(1) > 1);
+                        if has_wide {
+                            // Place each char at the *center* of its slot
+                            // (1 cell wide for ASCII, 2 cells wide for CJK).
+                            // This keeps the cursor / grid math right while
+                            // distributing the leftover space evenly so we
+                            // don't get a big right-side gap on every CJK
+                            // glyph.
+                            let mut col = run_start_col;
+                            for c in run_text.chars() {
+                                let w = unicode_width::UnicodeWidthChar::width(c)
+                                    .unwrap_or(1)
+                                    .max(1);
+                                let slot_x = origin.x + col as f32 * cell_w;
+                                let slot_w = w as f32 * cell_w;
+                                painter.text(
+                                    egui::pos2(slot_x + slot_w * 0.5, y + 1.0),
+                                    egui::Align2::CENTER_TOP,
+                                    c.to_string(),
+                                    fid.clone(),
+                                    run_fg,
+                                );
+                                col += w;
+                            }
+                        } else {
+                            let text_pos = egui::pos2(x, y + 1.0);
+                            painter.text(text_pos, egui::Align2::LEFT_TOP, run_text, fid, run_fg);
+                        }
                         if run_underline {
                             let ul_y = y + cell_h - 2.0;
                             painter.line_segment(
@@ -597,6 +680,55 @@ impl BerryCodeApp {
                     }
                 }
 
+                // ─── IME preedit overlay ───────────────────────
+                // Draw the in-progress IME composition string at the cursor
+                // with a subtle background + underline so the user can see
+                // what they're typing before they confirm with Enter.
+                if !self.terminal.ime_preedit.is_empty() && grid.scroll_offset == 0 {
+                    let preedit = &self.terminal.ime_preedit;
+                    let preedit_cells: usize = preedit
+                        .chars()
+                        .map(|c| {
+                            unicode_width::UnicodeWidthChar::width(c)
+                                .unwrap_or(1)
+                                .max(1)
+                        })
+                        .sum();
+                    let px = origin.x + grid.cursor_col as f32 * cell_w;
+                    let py = origin.y + grid.cursor_row as f32 * cell_h;
+                    let pw = preedit_cells as f32 * cell_w;
+                    let bg_rect =
+                        egui::Rect::from_min_size(egui::pos2(px, py), egui::vec2(pw, cell_h));
+                    painter.rect_filled(
+                        bg_rect,
+                        0.0,
+                        egui::Color32::from_rgba_unmultiplied(60, 90, 140, 110),
+                    );
+                    // Per-char positioning so CJK glyphs stay aligned with the
+                    // 2-cell terminal grid (see the comment in `flush` above).
+                    let mut col = grid.cursor_col;
+                    for c in preedit.chars() {
+                        let w = unicode_width::UnicodeWidthChar::width(c)
+                            .unwrap_or(1)
+                            .max(1);
+                        let slot_x = origin.x + col as f32 * cell_w;
+                        let slot_w = w as f32 * cell_w;
+                        painter.text(
+                            egui::pos2(slot_x + slot_w * 0.5, py + 1.0),
+                            egui::Align2::CENTER_TOP,
+                            c.to_string(),
+                            font_id.clone(),
+                            TERM_FG,
+                        );
+                        col += w;
+                    }
+                    let ul_y = py + cell_h - 1.0;
+                    painter.line_segment(
+                        [egui::pos2(px, ul_y), egui::pos2(px + pw, ul_y)],
+                        egui::Stroke::new(1.0, TERM_FG),
+                    );
+                }
+
                 // ─── Scrollbar ──────────────────────────────────
                 let sb_len = grid.scrollback.len();
                 let total_lines = sb_len + grid.rows;
@@ -661,13 +793,40 @@ impl BerryCodeApp {
     fn handle_terminal_keyboard(&mut self, ui: &mut egui::Ui, _response: &egui::Response) {
         let events: Vec<egui::Event> = ui.input(|i| i.events.clone());
 
+        if self.terminal.active_tab().is_none() {
+            return;
+        }
+
+        // Reset cursor blink on any input
+        let mut had_input = false;
+
+        // Process IME events first (they touch `self.terminal.ime_preedit`)
+        // so we can hold a `tab` borrow afterwards without aliasing.
+        for event in &events {
+            if let egui::Event::Ime(ime_event) = event {
+                match ime_event {
+                    egui::ImeEvent::Preedit(text) => {
+                        self.terminal.ime_preedit = text.clone();
+                        had_input = true;
+                    }
+                    egui::ImeEvent::Commit(text) => {
+                        self.terminal.ime_preedit.clear();
+                        if let Some(tab) = self.terminal.active_tab() {
+                            tab.write_to_pty(text.as_bytes());
+                        }
+                        had_input = true;
+                    }
+                    egui::ImeEvent::Enabled | egui::ImeEvent::Disabled => {
+                        self.terminal.ime_preedit.clear();
+                    }
+                }
+            }
+        }
+
         let tab = match self.terminal.active_tab() {
             Some(t) => t,
             None => return,
         };
-
-        // Reset cursor blink on any input
-        let mut had_input = false;
 
         for event in &events {
             match event {
@@ -678,15 +837,8 @@ impl BerryCodeApp {
                     tab.write_to_pty(text.as_bytes());
                     had_input = true;
                 }
-                egui::Event::Ime(ime_event) => {
-                    // Some platforms (notably macOS) deliver the committed
-                    // IME string as a separate Ime::Commit instead of Text.
-                    // Forward it so Japanese / Chinese / Korean characters
-                    // typed via IME reach the PTY in either path.
-                    if let egui::ImeEvent::Commit(text) = ime_event {
-                        tab.write_to_pty(text.as_bytes());
-                        had_input = true;
-                    }
+                egui::Event::Ime(_) => {
+                    // Already handled above.
                 }
                 egui::Event::Key {
                     key,

--- a/berrycode/src/app/terminal_emulator.rs
+++ b/berrycode/src/app/terminal_emulator.rs
@@ -1126,6 +1126,10 @@ pub struct TerminalEmulator {
     pub working_dir: String,
     pub cursor_blink_timer: f64,
     pub cursor_visible_blink: bool,
+    /// Live IME composition string. Populated from `ImeEvent::Preedit` and
+    /// drawn inline at the cursor; cleared on `ImeEvent::Commit`/`Disabled`.
+    /// Does not get written to the PTY — only the eventual commit does.
+    pub ime_preedit: String,
 }
 
 impl TerminalEmulator {
@@ -1137,6 +1141,7 @@ impl TerminalEmulator {
             working_dir: working_dir.to_string(),
             cursor_blink_timer: 0.0,
             cursor_visible_blink: true,
+            ime_preedit: String::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

### Terminal
- Auto-focus the fullscreen terminal panel when no other widget holds focus, and request focus on pointer press inside the grid. Without this, \`output.ime\` was never set and macOS/Windows IMEs stayed disabled, so Japanese keystrokes fell through as raw romaji.
- Forward \`ImeEvent::Preedit\` into a new \`TerminalEmulator::ime_preedit\` string and overlay it inline at the cursor (semi-transparent background + underline). Only the committed text is written to the PTY.
- Render CJK glyphs at exact cell positions (centred in their 2-cell slot) instead of relying on the proportional Japanese fallback font's natural advance, so the terminal cursor stays aligned with the visible text. Tightened \`cell_w\` ratio (0.6 → 0.575) to reduce inter-glyph gaps.

### Editor
- Count newlines via \`text.chars().take(idx)\` for the inline-blame cursor-line lookup. The previous byte-slice panicked whenever the cursor sat past a multi-byte glyph (egui's \`CCursor::index\` is a *char* index).
- Fix \`visuals.selection.stroke.color\` — egui uses it to *override* the glyph colour of selected text, not as a stroke. It was \`TRANSPARENT\`, which made IME preedit characters invisible. Use panel text colour and drop selection bg alpha.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo test --lib\` — 476/476 pass
- [x] Manual: open editor, type 日本語 via IME — preedit characters visible (no blue blackout)
- [x] Manual: open terminal, type 日本語 via IME — preedit shown inline, Enter commits to shell
- [x] Manual: type many CJK chars in terminal — cursor stays aligned with visible text