### PR TITLE
release: v0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "berrycode"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/berrycode/Cargo.toml
+++ b/berrycode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "berrycode"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "The IDE built for the Bevy game engine — Scene Editor, ECS Inspector, and more"
 authors = ["BerryCode Team"]


### PR DESCRIPTION
## v0.3.4

Patch release rolling up the recent bug fixes.

### Fixes
- **Scene Editor: multi-mesh GLB models** (#4 / #2) — render full scenes via Bevy's \`SceneRoot\` instead of extracting just the first primitive. Adds mesh-outline selection (no more 1×1×1 box on fox.glb-class models) for both Scene Editor and ECS Inspector.
- **Terminal: Japanese / IME support** (#6 / #3, #7) — CJK width handling, paste alignment, IME composition forwarding, inline preedit display, cursor alignment for proportional CJK fallback fonts.
- **Editor: Japanese input crash** (#7) — fixed panic when cursor sits past a multi-byte glyph, and the IME preedit selection no longer hides the composing characters.
- **Preview camera** (#5) — distinct camera order, layer-scoped ambient light, and a sane default orbit distance for typical GLB models. (GPU PBR preview itself, Issue #1, is still being investigated; CPU wireframe stays the default.)