### PR TITLE
release: v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "berrycode"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/berrycode/Cargo.toml
+++ b/berrycode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "berrycode"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 description = "The IDE built for the Bevy game engine — Scene Editor, ECS Inspector, and more"
 authors = ["BerryCode Team"]

--- a/berrycode/src/app/editor.rs
+++ b/berrycode/src/app/editor.rs
@@ -343,6 +343,44 @@ impl BerryCodeApp {
                     // Gutter = 64px left margin in TextEdit
                     let gutter_width = 64.0_f32;
 
+                    // While the LSP completion popup is visible, intercept
+                    // navigation / accept keys *before* TextEdit sees them.
+                    // - Tab / Enter: commit the selected suggestion
+                    // - Arrow Up / Down: move the highlight in the list
+                    // - PageUp / PageDown: jump 5 entries
+                    if self.lsp_show_completions && !self.lsp_completions.is_empty() {
+                        let total = self.lsp_completions.len();
+                        let (accept, up, down, pgup, pgdown) = ui.input_mut(|i| {
+                            (
+                                i.consume_key(egui::Modifiers::NONE, egui::Key::Tab)
+                                    || i.consume_key(egui::Modifiers::NONE, egui::Key::Enter),
+                                i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp),
+                                i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown),
+                                i.consume_key(egui::Modifiers::NONE, egui::Key::PageUp),
+                                i.consume_key(egui::Modifiers::NONE, egui::Key::PageDown),
+                            )
+                        });
+                        if accept {
+                            self.lsp_completion_accept_pending = true;
+                        }
+                        if up {
+                            self.lsp_completion_index = self
+                                .lsp_completion_index
+                                .checked_sub(1)
+                                .unwrap_or(total - 1);
+                        }
+                        if down {
+                            self.lsp_completion_index = (self.lsp_completion_index + 1) % total;
+                        }
+                        if pgup {
+                            self.lsp_completion_index = self.lsp_completion_index.saturating_sub(5);
+                        }
+                        if pgdown {
+                            self.lsp_completion_index =
+                                (self.lsp_completion_index + 5).min(total - 1);
+                        }
+                    }
+
                     let output = egui::TextEdit::multiline(&mut text)
                         .code_editor()
                         .desired_width(f32::INFINITY)
@@ -385,8 +423,25 @@ impl BerryCodeApp {
                         })
                         .show(ui);
 
-                    // Auto-close brackets: if a bracket was just typed, insert closing pair
-                    if !is_readonly && output.response.changed() {
+                    // Auto-close brackets: only when the user *typed* a
+                    // bracket this frame. Checking `response.changed()` alone
+                    // also fires for undo / programmatic edits, which used
+                    // to re-insert orphaned `}` after `Cmd+Z`. Gate on a
+                    // matching `Event::Text` event in the input queue.
+                    let typed_bracket: Option<char> = ui.input(|i| {
+                        for ev in &i.events {
+                            if let egui::Event::Text(t) = ev {
+                                if t.len() == 1 {
+                                    let c = t.chars().next().unwrap();
+                                    if matches!(c, '(' | '{' | '[' | '"' | '\'') {
+                                        return Some(c);
+                                    }
+                                }
+                            }
+                        }
+                        None
+                    });
+                    if !is_readonly && typed_bracket.is_some() && output.response.changed() {
                         if let Some(cr) = output.cursor_range {
                             let cursor_pos = cr.primary.index;
                             if cursor_pos > 0 {
@@ -422,8 +477,17 @@ impl BerryCodeApp {
                                     _ => None,
                                 };
                                 if let Some(close_char) = closing {
-                                    // Insert closing bracket at cursor position
-                                    text.insert(cursor_pos, close_char);
+                                    // `cursor_pos` is a char index (egui's
+                                    // CCursor); `String::insert` wants a byte
+                                    // index. Convert via char_indices() so we
+                                    // don't slice through a multi-byte glyph
+                                    // when there's CJK before the cursor.
+                                    let byte_pos = text
+                                        .char_indices()
+                                        .nth(cursor_pos)
+                                        .map(|(b, _)| b)
+                                        .unwrap_or(text.len());
+                                    text.insert(byte_pos, close_char);
                                     // Don't move cursor - it should stay between the brackets
                                 }
                             }
@@ -469,7 +533,12 @@ impl BerryCodeApp {
                                     }
 
                                     if !indent.is_empty() {
-                                        text.insert_str(cursor_pos, &indent);
+                                        let byte_pos = text
+                                            .char_indices()
+                                            .nth(cursor_pos)
+                                            .map(|(b, _)| b)
+                                            .unwrap_or(text.len());
+                                        text.insert_str(byte_pos, &indent);
                                     }
                                 }
                             }
@@ -504,9 +573,15 @@ impl BerryCodeApp {
                         }
 
                         // Auto-trigger completions only on actual keyboard typing
-                        // (not on programmatic text changes like completion insert)
-                        let had_key_input = ui
-                            .input(|i| i.events.iter().any(|e| matches!(e, egui::Event::Text(_))));
+                        // (not on programmatic text changes like completion insert).
+                        // Treat IME-committed strings as typing too, so 日本語
+                        // input still pops the completion list.
+                        let had_key_input = ui.input(|i| {
+                            i.events.iter().any(|e| {
+                                matches!(e, egui::Event::Text(_))
+                                    || matches!(e, egui::Event::Ime(egui::ImeEvent::Commit(_)))
+                            })
+                        });
                         if had_key_input {
                             if let Some(cr) = output.cursor_range {
                                 let cursor_pos = cr.primary.index;
@@ -522,6 +597,17 @@ impl BerryCodeApp {
                                     });
                                     if should_trigger {
                                         self.lsp_auto_trigger_pending = true;
+                                    }
+                                    // Signature help: '(' opens it, ',' moves
+                                    // to the next param, ')' closes it.
+                                    match last_char {
+                                        Some('(') | Some(',') => {
+                                            self.lsp_signature_trigger_pending = true;
+                                        }
+                                        Some(')') => {
+                                            self.lsp_signature_help = None;
+                                        }
+                                        _ => {}
                                     }
                                 }
                             }
@@ -573,11 +659,15 @@ impl BerryCodeApp {
                     }
 
                     // === Gutter: [BP dot | line number | fold icon] ===
-                    // All positions relative to editor_rect.min.x (left edge of TextEdit)
-                    // gutter_width = 64px, text starts at editor_rect.min.x + 64
-                    // editor_rect = inner rect (margin excluded), text starts at editor_rect.min.x
-                    // Gutter is in the margin area: BEFORE editor_rect.min.x
-                    let gutter_left = editor_rect.min.x - gutter_width;
+                    // The gutter sits exactly `gutter_width` left of where the
+                    // text actually starts drawing. Anchoring to `text_origin`
+                    // (egui's reported galley position) keeps the math correct
+                    // regardless of whether the TextEdit's response rect
+                    // includes its margin or not — egui 0.33 changed this and
+                    // the previous `editor_rect.min.x - gutter_width` placed
+                    // the gutter outside the editor's clip rect, hiding the
+                    // line numbers.
+                    let gutter_left = text_origin.x - gutter_width;
                     let bp_center_x = gutter_left + 10.0; // breakpoint dot
                     let line_num_right_x = gutter_left + 42.0; // line number right-align
                     let fold_center_x = gutter_left + 54.0; // fold icon center
@@ -1335,8 +1425,14 @@ impl BerryCodeApp {
                         text
                     };
 
-                    // Return gutter layout info for click handling outside ScrollArea
-                    let gutter_info = (gutter_left, fold_center_x, bp_center_x, editor_rect);
+                    // Return gutter layout info for click handling outside ScrollArea.
+                    // Use a synthetic rect for the gutter so the click handler doesn't
+                    // depend on whether `editor_rect` includes the margin or not.
+                    let gutter_rect = egui::Rect::from_min_max(
+                        egui::pos2(gutter_left, editor_rect.min.y),
+                        egui::pos2(text_origin.x, editor_rect.max.y),
+                    );
+                    let gutter_info = (gutter_left, fold_center_x, bp_center_x, gutter_rect);
                     (
                         output,
                         go_to_def_data,
@@ -1375,12 +1471,11 @@ impl BerryCodeApp {
 
                     if clicked {
                         if let Some(pos) = click_pos {
-                            // Check if click is in the gutter area (between gutter_left and editor_rect.min.x)
-                            if pos.x >= gutter_left
-                                && pos.x < ed_rect.min.x
-                                && pos.y >= ed_rect.min.y
-                                && pos.y <= ed_rect.max.y
-                            {
+                            // `ed_rect` here is the synthetic gutter rect:
+                            // [gutter_left .. text_origin.x] horizontally, full
+                            // editor height vertically. Click anywhere inside
+                            // is a gutter click.
+                            if ed_rect.contains(pos) {
                                 // Calculate line from Y position
                                 let relative_y =
                                     pos.y - ed_rect.min.y + scroll_output.state.offset.y;
@@ -1520,6 +1615,11 @@ impl BerryCodeApp {
             self.lsp_auto_trigger_pending = false;
             self.trigger_lsp_completions();
         }
+        // Auto-trigger signature help when '(' or ',' is typed.
+        if self.lsp_signature_trigger_pending && self.lsp_connected {
+            self.lsp_signature_trigger_pending = false;
+            self.trigger_lsp_signature_help();
+        }
 
         // Handle keyboard shortcuts for LSP
         self.handle_lsp_shortcuts(ctx);
@@ -1527,6 +1627,10 @@ impl BerryCodeApp {
         // Render completion popup
         if self.lsp_show_completions && !self.lsp_completions.is_empty() {
             self.render_lsp_completions(ctx);
+        }
+        // Render signature-help popup
+        if self.lsp_signature_help.is_some() {
+            self.render_lsp_signature_help(ctx);
         }
 
         // Render code actions popup (💡 menu)

--- a/berrycode/src/app/events.rs
+++ b/berrycode/src/app/events.rs
@@ -202,6 +202,9 @@ impl BerryCodeApp {
                             t.is_readonly = true;
                         }
                     }
+                    LspResponse::SignatureHelp(help) => {
+                        self.lsp_signature_help = help;
+                    }
                 }
             }
         }

--- a/berrycode/src/app/lsp.rs
+++ b/berrycode/src/app/lsp.rs
@@ -1,5 +1,6 @@
 //! LSP integration: completions, diagnostics, hover, go-to-definition, find references
 
+use super::types;
 use super::types::{
     DiagnosticSeverity, LspCompletionItem, LspDiagnostic, LspHoverInfo, LspLocation, LspResponse,
     PendingGotoDefinition,
@@ -20,12 +21,21 @@ impl BerryCodeApp {
 
         ctx.input(|i| {
             if i.modifiers.command && i.key_pressed(egui::Key::Space) {
-                self.trigger_lsp_completions();
+                if i.modifiers.shift {
+                    self.trigger_lsp_signature_help();
+                } else {
+                    self.trigger_lsp_completions();
+                }
             }
 
-            if i.key_pressed(egui::Key::Escape) && self.lsp_show_completions {
-                self.lsp_show_completions = false;
-                self.lsp_completions.clear();
+            if i.key_pressed(egui::Key::Escape) {
+                if self.lsp_show_completions {
+                    self.lsp_show_completions = false;
+                    self.lsp_completions.clear();
+                }
+                if self.lsp_signature_help.is_some() {
+                    self.lsp_signature_help = None;
+                }
             }
         });
     }
@@ -153,6 +163,212 @@ impl BerryCodeApp {
         self.lsp_show_completions = true;
     }
 
+    /// Trigger `textDocument/signatureHelp` for the cursor position. Called
+    /// when `(` or `,` is typed inside a function call, or via Cmd+Shift+Space.
+    pub(crate) fn trigger_lsp_signature_help(&mut self) {
+        let tab = match self.editor_tabs.get(self.active_tab_idx) {
+            Some(t) => t,
+            None => return,
+        };
+        let file_path = tab.file_path.clone();
+        let line = tab.cursor_line;
+        let utf8_column = tab.cursor_col;
+
+        let utf16_column = {
+            let text = tab.buffer.to_string();
+            let lines: Vec<&str> = text.lines().collect();
+            if line < lines.len() {
+                utf8_offset_to_utf16(lines[line], utf8_column)
+            } else {
+                utf8_column
+            }
+        };
+
+        let client = match &self.lsp_native_client {
+            Some(c) => std::sync::Arc::clone(c),
+            None => return,
+        };
+        let tx = match &self.lsp_response_tx {
+            Some(t) => t.clone(),
+            None => return,
+        };
+        let runtime = std::sync::Arc::clone(&self.lsp_runtime);
+
+        runtime.spawn(async move {
+            let lang = match crate::native::lsp_native::detect_server_language(&file_path) {
+                Some(l) => l,
+                None => return,
+            };
+            match client
+                .get_signature_help(lang, file_path, line as u32, utf16_column as u32)
+                .await
+            {
+                Ok(Some(sig)) => {
+                    let signatures: Vec<types::LspSignatureInfo> = sig
+                        .signatures
+                        .iter()
+                        .map(|s| {
+                            let label = s.label.clone();
+                            let documentation = s.documentation.as_ref().and_then(|d| match d {
+                                lsp_types::Documentation::String(s) => Some(s.clone()),
+                                lsp_types::Documentation::MarkupContent(m) => Some(m.value.clone()),
+                            });
+                            let param_ranges: Vec<(usize, usize)> = s
+                                .parameters
+                                .as_ref()
+                                .map(|params| {
+                                    params
+                                        .iter()
+                                        .filter_map(|p| match &p.label {
+                                            lsp_types::ParameterLabel::Simple(s) => {
+                                                label.find(s.as_str()).map(|i| (i, i + s.len()))
+                                            }
+                                            lsp_types::ParameterLabel::LabelOffsets(off) => {
+                                                Some((off[0] as usize, off[1] as usize))
+                                            }
+                                        })
+                                        .collect()
+                                })
+                                .unwrap_or_default();
+                            types::LspSignatureInfo {
+                                label,
+                                documentation,
+                                param_ranges,
+                            }
+                        })
+                        .collect();
+                    let normalised = types::LspSignatureHelp {
+                        signatures,
+                        active_signature: sig.active_signature.unwrap_or(0) as usize,
+                        active_parameter: sig.active_parameter.map(|p| p as usize),
+                    };
+                    let _ = tx.send(LspResponse::SignatureHelp(Some(normalised)));
+                }
+                _ => {
+                    let _ = tx.send(LspResponse::SignatureHelp(None));
+                }
+            }
+        });
+    }
+
+    /// Render the floating signature-help popup (VS Code-style: monospace
+    /// signature with the active parameter underlined, optional doc below).
+    pub(crate) fn render_lsp_signature_help(&mut self, ctx: &egui::Context) {
+        let help = match &self.lsp_signature_help {
+            Some(h) if !h.signatures.is_empty() => h.clone(),
+            _ => return,
+        };
+
+        let signature = match help.signatures.get(help.active_signature) {
+            Some(s) => s,
+            None => return,
+        };
+
+        // Anchor the popup near the editor's cursor. We don't have the exact
+        // pixel position from this scope, so place it under the active editor
+        // panel using a reasonable offset; the user can scroll the editor
+        // independently and the popup tracks pointer / cursor position.
+        let pointer = ctx.input(|i| i.pointer.hover_pos());
+        let anchor = pointer
+            .map(|p| egui::pos2(p.x, p.y + 24.0))
+            .unwrap_or_else(|| egui::pos2(80.0, 80.0));
+
+        egui::Area::new(egui::Id::new("lsp_signature_help_popup"))
+            .order(egui::Order::Foreground)
+            .fixed_pos(anchor)
+            .show(ctx, |ui| {
+                egui::Frame::popup(ui.style())
+                    .fill(egui::Color32::from_rgb(35, 36, 40))
+                    .stroke(egui::Stroke::new(
+                        1.0,
+                        egui::Color32::from_rgb(75, 110, 175),
+                    ))
+                    .inner_margin(egui::Margin::same(8))
+                    .show(ui, |ui| {
+                        ui.set_max_width(560.0);
+
+                        // Build a coloured layout job: active parameter is
+                        // bright + bold, the rest dim.
+                        let mut job = egui::text::LayoutJob::default();
+                        let active = help.active_parameter.unwrap_or(usize::MAX);
+                        let active_range = signature.param_ranges.get(active).copied();
+                        let label = &signature.label;
+
+                        let dim = egui::Color32::from_rgb(180, 180, 190);
+                        let bright = egui::Color32::from_rgb(255, 255, 255);
+                        let accent = egui::Color32::from_rgb(120, 200, 255);
+
+                        match active_range {
+                            Some((s, e)) if s < label.len() && e <= label.len() && s < e => {
+                                job.append(
+                                    &label[..s],
+                                    0.0,
+                                    egui::TextFormat {
+                                        font_id: egui::FontId::monospace(13.0),
+                                        color: dim,
+                                        ..Default::default()
+                                    },
+                                );
+                                job.append(
+                                    &label[s..e],
+                                    0.0,
+                                    egui::TextFormat {
+                                        font_id: egui::FontId::monospace(13.0),
+                                        color: accent,
+                                        underline: egui::Stroke::new(1.0, accent),
+                                        ..Default::default()
+                                    },
+                                );
+                                job.append(
+                                    &label[e..],
+                                    0.0,
+                                    egui::TextFormat {
+                                        font_id: egui::FontId::monospace(13.0),
+                                        color: dim,
+                                        ..Default::default()
+                                    },
+                                );
+                            }
+                            _ => {
+                                job.append(
+                                    label,
+                                    0.0,
+                                    egui::TextFormat {
+                                        font_id: egui::FontId::monospace(13.0),
+                                        color: bright,
+                                        ..Default::default()
+                                    },
+                                );
+                            }
+                        }
+                        ui.label(job);
+
+                        if help.signatures.len() > 1 {
+                            ui.label(
+                                egui::RichText::new(format!(
+                                    "{}/{} overloads — Cmd+Shift+Space to cycle",
+                                    help.active_signature + 1,
+                                    help.signatures.len()
+                                ))
+                                .small()
+                                .color(egui::Color32::from_rgb(140, 140, 150)),
+                            );
+                        }
+
+                        if let Some(doc) = &signature.documentation {
+                            if !doc.trim().is_empty() {
+                                ui.separator();
+                                ui.label(
+                                    egui::RichText::new(doc)
+                                        .small()
+                                        .color(egui::Color32::from_rgb(200, 200, 210)),
+                                );
+                            }
+                        }
+                    });
+            });
+    }
+
     /// Render LSP completion popup (VS Code style)
     pub(crate) fn render_lsp_completions(&mut self, ctx: &egui::Context) {
         // Get the current word being typed (for filtering)
@@ -212,18 +428,36 @@ impl BerryCodeApp {
 
         let mut selected_item: Option<String> = None;
 
-        // Enter/Tab to accept selected item
-        if ctx.input(|i| i.key_pressed(egui::Key::Tab) || i.key_pressed(egui::Key::Enter)) {
+        // Accept on Tab/Enter. The actual key was consumed in `editor.rs`
+        // *before* the `TextEdit` widget rendered so it never reached the
+        // editor as a newline; this flag is the signal that happened.
+        let accepted = std::mem::take(&mut self.lsp_completion_accept_pending);
+        if accepted {
             if let Some(item) = filtered.get(self.lsp_completion_index) {
                 selected_item = Some(item.insert_text.clone().unwrap_or(item.label.clone()));
             }
         }
 
-        // Click outside to dismiss
+        // Position popup below cursor
+        let popup_pos = if let Some(tab) = self.editor_tabs.get(self.active_tab_idx) {
+            // Approximate: gutter(64) + sidebar(280) + char_width(7.8) * col
+            let x = 64.0 + 280.0 + (tab.cursor_col as f32 * 7.8);
+            // header(32) + line_height(19.5) * (visible_line + 1)
+            let y = 32.0 + ((tab.cursor_line as f32 + 1.0) * 19.5).min(500.0);
+            egui::pos2(x.min(600.0), y)
+        } else {
+            egui::pos2(350.0, 150.0)
+        };
+
+        // Click outside to dismiss. Use the actual popup rect (not a stale
+        // hard-coded one) so clicks INSIDE the popup are correctly treated
+        // as item-clicks rather than as outside-clicks that dismiss it.
+        let popup_rect = egui::Rect::from_min_size(
+            popup_pos,
+            egui::vec2(400.0, (filtered.len().min(10) as f32) * 20.0 + 4.0),
+        );
         if ctx.input(|i| i.pointer.any_pressed()) {
             let click_pos = ctx.input(|i| i.pointer.interact_pos());
-            let popup_rect =
-                egui::Rect::from_min_size(egui::pos2(350.0, 150.0), egui::vec2(400.0, 220.0));
             if let Some(pos) = click_pos {
                 if !popup_rect.contains(pos) {
                     self.lsp_show_completions = false;
@@ -240,17 +474,6 @@ impl BerryCodeApp {
             let text_color = egui::Color32::from_rgb(212, 212, 212);
             let detail_color = egui::Color32::from_rgb(110, 110, 110);
             let max_items = 10;
-
-            // Position popup below cursor
-            let popup_pos = if let Some(tab) = self.editor_tabs.get(self.active_tab_idx) {
-                // Approximate: gutter(64) + sidebar(280) + char_width(7.8) * col
-                let x = 64.0 + 280.0 + (tab.cursor_col as f32 * 7.8);
-                // header(32) + line_height(19.5) * (visible_line + 1)
-                let y = 32.0 + ((tab.cursor_line as f32 + 1.0) * 19.5).min(500.0);
-                egui::pos2(x.min(600.0), y)
-            } else {
-                egui::pos2(350.0, 150.0)
-            };
 
             egui::Area::new(egui::Id::new("lsp_completions"))
                 .order(egui::Order::Foreground)

--- a/berrycode/src/app/mod.rs
+++ b/berrycode/src/app/mod.rs
@@ -251,6 +251,12 @@ pub struct BerryCodeApp {
     pub(crate) lsp_show_hover: bool,
     pub(crate) lsp_auto_trigger_pending: bool,
     pub(crate) lsp_completion_index: usize,
+    /// Latest `textDocument/signatureHelp` result. Cleared when the cursor
+    /// leaves a parameter list (`)` typed, Esc pressed, etc.).
+    pub(crate) lsp_signature_help: Option<types::LspSignatureHelp>,
+    /// `(` was just typed → trigger a signature-help request next frame
+    /// (paralleling `lsp_auto_trigger_pending` for completions).
+    pub(crate) lsp_signature_trigger_pending: bool,
     pub(crate) lsp_response_rx: Option<mpsc::UnboundedReceiver<LspResponse>>,
     pub(crate) lsp_diagnostics_rx:
         Option<mpsc::UnboundedReceiver<native::lsp_native::PublishedDiagnostics>>,
@@ -573,6 +579,22 @@ pub struct BerryCodeApp {
 
     // === Customizable Keyboard Shortcuts ===
     pub(crate) keymap: keymap::Keymap,
+    /// When `Some`, the Settings → Keybindings panel is capturing the next
+    /// key press to rebind this action. Cleared once a chord arrives or the
+    /// user cancels with `Esc`.
+    pub(crate) keybinding_recording: Option<keymap::KeyAction>,
+    /// Transient feedback string shown under the keybinding grid (e.g.
+    /// "Cmd+S already bound to Save"). Cleared when the user starts a new
+    /// recording.
+    pub(crate) keybinding_message: Option<String>,
+    /// Currently active visual theme preset (Dark / Light / High Contrast).
+    /// Persisted under `~/.berrycode/theme.json` so the choice survives
+    /// restarts.
+    pub(crate) theme_mode: types::ThemeMode,
+    /// `true` if the LSP completion popup pre-consumed Enter / Tab this
+    /// frame so the editor's `TextEdit` won't treat it as a newline. Read
+    /// and cleared by `render_lsp_completions`.
+    pub(crate) lsp_completion_accept_pending: bool,
 
     // === Dockable Tool Panel ===
     pub(crate) tool_panel_open: bool,
@@ -689,7 +711,7 @@ impl BerryCodeApp {
                                                              // Selection bg uses RGBA with alpha so the underlying text remains
                                                              // legible during IME preedit (egui paints selection over the glyphs).
                                                              // Premultiplied alpha: ~30% opacity = (rgb * 0.3, alpha 76).
-        let bg_selected = egui::Color32::from_rgba_premultiplied(11, 24, 42, 76);
+        let bg_selected = egui::Color32::from_rgba_premultiplied(20, 40, 70, 130);
         let border = egui::Color32::from_rgb(60, 63, 68); // borders
         let border_focus = egui::Color32::from_rgb(75, 110, 175); // focused border (accent)
         let text = egui::Color32::from_rgb(205, 207, 213); // primary text
@@ -1291,6 +1313,8 @@ impl BerryCodeApp {
             lsp_completions: Vec::new(),
             lsp_show_completions: false,
             lsp_auto_trigger_pending: false,
+            lsp_signature_help: None,
+            lsp_signature_trigger_pending: false,
             lsp_completion_index: 0,
             lsp_show_hover: false,
             lsp_response_rx: Some(lsp_rx),
@@ -1584,6 +1608,10 @@ impl BerryCodeApp {
             player_settings: scene_editor::build_settings::PlayerSettings::default(),
 
             keymap: keymap::Keymap::load(),
+            keybinding_recording: None,
+            keybinding_message: None,
+            theme_mode: load_theme_mode(),
+            lsp_completion_accept_pending: false,
 
             tool_panel_open: false,
             active_tool_tab: dock::ToolTab::Console,
@@ -1744,6 +1772,72 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::
 #[derive(bevy::prelude::Resource, Default)]
 pub struct EguiFontsConfigured(pub bool);
 
+/// Where the chosen visual theme is persisted between sessions.
+fn theme_mode_path() -> std::path::PathBuf {
+    if let Some(home) = dirs::home_dir() {
+        let dir = home.join(".berrycode");
+        std::fs::create_dir_all(&dir).ok();
+        dir.join("theme.json")
+    } else {
+        std::path::PathBuf::from("theme.json")
+    }
+}
+
+fn load_theme_mode() -> types::ThemeMode {
+    let path = theme_mode_path();
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<types::ThemeMode>(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_theme_mode(mode: types::ThemeMode) {
+    let path = theme_mode_path();
+    if let Ok(json) = serde_json::to_string_pretty(&mode) {
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+/// Build an `egui::Visuals` for the given theme preset. Centralised so the
+/// startup path and the runtime theme switcher always agree on colours.
+pub fn visuals_for_theme(mode: types::ThemeMode) -> egui::Visuals {
+    let mut v = match mode {
+        types::ThemeMode::Light => egui::Visuals::light(),
+        _ => egui::Visuals::dark(),
+    };
+    let (panel, text, accent, sel_bg, sel_text) = match mode {
+        types::ThemeMode::Dark => (
+            egui::Color32::from_rgb(25, 26, 28),
+            egui::Color32::from_rgb(212, 212, 212),
+            egui::Color32::from_rgb(75, 110, 175),
+            egui::Color32::from_rgba_premultiplied(20, 40, 70, 130),
+            egui::Color32::from_rgb(212, 212, 212),
+        ),
+        types::ThemeMode::Light => (
+            egui::Color32::from_rgb(245, 246, 248),
+            egui::Color32::from_rgb(35, 38, 44),
+            egui::Color32::from_rgb(50, 100, 200),
+            egui::Color32::from_rgba_premultiplied(70, 130, 220, 110),
+            egui::Color32::from_rgb(35, 38, 44),
+        ),
+        types::ThemeMode::HighContrast => (
+            egui::Color32::BLACK,
+            egui::Color32::WHITE,
+            egui::Color32::from_rgb(0, 200, 255),
+            egui::Color32::from_rgba_premultiplied(0, 200, 255, 120),
+            egui::Color32::WHITE,
+        ),
+    };
+    v.panel_fill = panel;
+    v.window_fill = panel;
+    v.extreme_bg_color = panel;
+    v.override_text_color = Some(text);
+    v.hyperlink_color = accent;
+    v.selection.bg_fill = sel_bg;
+    v.selection.stroke = egui::Stroke::new(0.0, sel_text);
+    v
+}
+
 /// Bevy update system: configure egui fonts and style (runs once on first successful access).
 pub fn setup_egui_fonts_and_style(
     mut egui_ctx: bevy_egui::EguiContexts,
@@ -1836,23 +1930,11 @@ pub fn setup_egui_fonts_and_style(
 
     ctx.set_fonts(fonts);
 
-    // Custom dark theme with #191a1c background and unified #D4D4D4 white
-    let mut visuals = egui::Visuals::dark();
-    visuals.override_text_color = Some(egui::Color32::from_rgb(212, 212, 212));
-    visuals.panel_fill = egui::Color32::from_rgb(25, 26, 28);
-    visuals.window_fill = egui::Color32::from_rgb(25, 26, 28);
-    visuals.extreme_bg_color = egui::Color32::from_rgb(25, 26, 28);
-    visuals.widgets.noninteractive.bg_fill = egui::Color32::from_rgb(25, 26, 28);
-    visuals.widgets.inactive.bg_fill = egui::Color32::from_rgb(25, 26, 28);
-    visuals.widgets.hovered.bg_fill = egui::Color32::from_rgb(45, 47, 50);
-    visuals.widgets.active.bg_fill = egui::Color32::from_rgb(60, 63, 65);
-    visuals.selection.bg_fill = egui::Color32::from_rgba_premultiplied(11, 24, 42, 76);
-    // `selection.stroke.color` is the text color override for selected glyphs.
-    visuals.selection.stroke = egui::Stroke::new(0.0, egui::Color32::from_rgb(212, 212, 212));
-    visuals.code_bg_color = egui::Color32::from_rgb(25, 26, 28);
-    ctx.set_visuals(visuals);
+    // Apply the persisted theme preset. Defaults to Dark on first run.
+    ctx.set_visuals(visuals_for_theme(load_theme_mode()));
 
-    // Also apply the One Dark style
+    // Also apply the One Dark style (panel-specific tweaks; visuals_for_theme
+    // covers the colour-scheme defaults).
     BerryCodeApp::setup_egui_style(ctx);
 
     tracing::info!("egui fonts and style configured");

--- a/berrycode/src/app/settings.rs
+++ b/berrycode/src/app/settings.rs
@@ -111,12 +111,36 @@ impl BerryCodeApp {
                             ui.label(self.tr("Window theme, font settings, etc."));
                             ui.add_space(12.0);
 
+                            // Theme preset switcher — applies + persists
+                            // immediately so the user sees the change live.
+                            ui.label(egui::RichText::new("Theme preset").strong());
+                            ui.add_space(4.0);
+                            let presets = [
+                                super::types::ThemeMode::Dark,
+                                super::types::ThemeMode::Light,
+                                super::types::ThemeMode::HighContrast,
+                            ];
+                            ui.horizontal(|ui| {
+                                for mode in presets {
+                                    let selected = self.theme_mode == mode;
+                                    if ui.selectable_label(selected, mode.label()).clicked()
+                                        && !selected
+                                    {
+                                        self.theme_mode = mode;
+                                        ui.ctx().set_visuals(super::visuals_for_theme(mode));
+                                        super::save_theme_mode(mode);
+                                    }
+                                }
+                            });
+                            ui.add_space(12.0);
+
                             // Font size info
                             ui.label("Editor font: monospace 13.0px (default)");
                             ui.add_space(8.0);
 
-                            // Theme selector
-                            ui.label("Theme:");
+                            // Advanced theme tools
+                            ui.label(egui::RichText::new("Advanced").strong());
+                            ui.add_space(4.0);
                             ui.horizontal(|ui| {
                                 if ui.button("Open Theme Editor").clicked() {
                                     self.show_theme_editor = true;
@@ -408,36 +432,146 @@ impl BerryCodeApp {
 
     /// Keyboard Shortcuts settings tab
     pub(crate) fn render_keybindings_settings(&mut self, ui: &mut egui::Ui) {
-        use super::keymap::KeyAction;
+        use super::keymap::{KeyAction, KeyBinding};
 
         ui.heading(self.tr("Keybindings"));
         ui.add_space(4.0);
-        ui.label(
-            "Current keybinding assignments. Edit keybindings.ron for advanced customization.",
-        );
+        ui.label("Click a shortcut to rebind it. Press Esc to cancel.");
         ui.add_space(8.0);
         ui.separator();
         ui.add_space(4.0);
 
+        // Capture the next key press while a recording is active. We do this
+        // before rendering the grid so the new binding is reflected
+        // immediately in the same frame.
+        if let Some(target) = self.keybinding_recording {
+            let captured = ui.input(|i| {
+                if i.key_pressed(egui::Key::Escape) {
+                    return Some(None); // cancel
+                }
+                for ev in &i.events {
+                    if let egui::Event::Key {
+                        key,
+                        pressed: true,
+                        modifiers,
+                        ..
+                    } = ev
+                    {
+                        // Ignore modifier-only key events (Cmd / Shift / Alt
+                        // by themselves shouldn't count as a binding).
+                        let is_modifier = matches!(key, egui::Key::Backtick | egui::Key::Escape);
+                        if is_modifier {
+                            continue;
+                        }
+                        let new_binding = KeyBinding {
+                            command: modifiers.command,
+                            shift: modifiers.shift,
+                            alt: modifiers.alt,
+                            key: format!("{:?}", key),
+                        };
+                        return Some(Some(new_binding));
+                    }
+                }
+                None
+            });
+
+            match captured {
+                Some(None) => {
+                    self.keybinding_recording = None;
+                    self.keybinding_message =
+                        Some(format!("Cancelled (no change to {})", target.label()));
+                }
+                Some(Some(new_binding)) => {
+                    // Detect conflict — another action already uses this chord.
+                    let conflict = self
+                        .keymap
+                        .bindings
+                        .iter()
+                        .find(|(act, b)| {
+                            **act != target
+                                && b.command == new_binding.command
+                                && b.shift == new_binding.shift
+                                && b.alt == new_binding.alt
+                                && b.key == new_binding.key
+                        })
+                        .map(|(a, _)| *a);
+
+                    if let Some(conflict_action) = conflict {
+                        self.keybinding_message = Some(format!(
+                            "{} already bound to {}",
+                            new_binding.display(),
+                            conflict_action.label()
+                        ));
+                    } else {
+                        let display = new_binding.display();
+                        self.keymap.bindings.insert(target, new_binding);
+                        self.keymap.save();
+                        self.keybinding_message = Some(format!("{} → {}", target.label(), display));
+                    }
+                    self.keybinding_recording = None;
+                }
+                None => {}
+            }
+        }
+
         egui::Grid::new("keybindings_grid")
-            .num_columns(2)
-            .spacing([20.0, 4.0])
+            .num_columns(3)
+            .spacing([16.0, 4.0])
             .striped(true)
             .show(ui, |ui| {
                 ui.strong("Action");
                 ui.strong("Shortcut");
+                ui.strong("");
                 ui.end_row();
 
                 for action in KeyAction::ALL {
                     ui.label(action.label());
-                    if let Some(binding) = self.keymap.bindings.get(action) {
-                        ui.monospace(binding.display());
+
+                    let is_recording = self.keybinding_recording == Some(*action);
+                    let label = if is_recording {
+                        "Press a key…".to_string()
                     } else {
-                        ui.label("(unbound)");
+                        self.keymap
+                            .bindings
+                            .get(action)
+                            .map(|b| b.display())
+                            .unwrap_or_else(|| "(unbound)".to_string())
+                    };
+
+                    let button = egui::Button::new(egui::RichText::new(&label).monospace())
+                        .min_size(egui::vec2(140.0, 22.0))
+                        .fill(if is_recording {
+                            egui::Color32::from_rgb(60, 90, 140)
+                        } else {
+                            egui::Color32::TRANSPARENT
+                        });
+
+                    if ui.add(button).clicked() {
+                        self.keybinding_recording = Some(*action);
+                        self.keybinding_message = None;
+                    }
+
+                    if !is_recording && self.keymap.bindings.contains_key(action) {
+                        if ui.small_button("Clear").clicked() {
+                            self.keymap.bindings.remove(action);
+                            self.keymap.save();
+                            self.keybinding_message = Some(format!("Cleared {}", action.label()));
+                        }
+                    } else {
+                        ui.label("");
                     }
                     ui.end_row();
                 }
             });
+
+        ui.add_space(8.0);
+        if let Some(msg) = &self.keybinding_message {
+            ui.label(
+                egui::RichText::new(msg)
+                    .small()
+                    .color(egui::Color32::from_rgb(180, 200, 230)),
+            );
+        }
 
         ui.add_space(12.0);
         ui.separator();
@@ -447,11 +581,14 @@ impl BerryCodeApp {
             if ui.button("Reset to Defaults").clicked() {
                 self.keymap = super::keymap::Keymap::default();
                 self.keymap.save();
+                self.keybinding_recording = None;
+                self.keybinding_message = Some("Reset to defaults".to_string());
                 tracing::info!("Keyboard shortcuts reset to defaults");
             }
 
             if ui.button("Save to File").clicked() {
                 self.keymap.save();
+                self.keybinding_message = Some("Saved".to_string());
                 tracing::info!("Keyboard shortcuts saved");
             }
         });

--- a/berrycode/src/app/types.rs
+++ b/berrycode/src/app/types.rs
@@ -125,6 +125,35 @@ pub enum SettingsTab {
     GitHub,
 }
 
+/// Top-level visual theme preset. Each variant maps to a full
+/// `egui::Visuals` configuration, applied immediately when the user picks
+/// a different option in `Settings → Appearance`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ThemeMode {
+    /// Default — One Dark / Darcula-inspired dark theme.
+    Dark,
+    /// Bright background, lower contrast — for daylight / outdoor use.
+    Light,
+    /// Pure black + white with WCAG AAA contrast for accessibility.
+    HighContrast,
+}
+
+impl Default for ThemeMode {
+    fn default() -> Self {
+        Self::Dark
+    }
+}
+
+impl ThemeMode {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Dark => "Dark",
+            Self::Light => "Light",
+            Self::HighContrast => "High Contrast",
+        }
+    }
+}
+
 // ===== NEW: Git UI Tabs (SourceTree-compatible) =====
 
 /// Git panel tabs (6 tabs: Status, History, Branches, Remotes, Tags, Stash)
@@ -309,6 +338,27 @@ pub enum LspResponse {
     InlayHints(Vec<LspInlayHint>),
     CodeActions(Vec<LspCodeAction>),
     MacroExpansion(String, String), // (macro_name, expanded_text)
+    SignatureHelp(Option<LspSignatureHelp>),
+}
+
+/// Snapshot of a single signature returned by the LSP server, normalised
+/// into a form the editor popup can render directly.
+#[derive(Debug, Clone)]
+pub struct LspSignatureInfo {
+    /// The full signature label, e.g. `fn spawn<T: Bundle>(bundle: T) -> EntityCommands<'_>`.
+    pub label: String,
+    /// Optional documentation pulled from the language server.
+    pub documentation: Option<String>,
+    /// Byte ranges into `label` that locate each parameter, used to
+    /// underline / bold the active one.
+    pub param_ranges: Vec<(usize, usize)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LspSignatureHelp {
+    pub signatures: Vec<LspSignatureInfo>,
+    pub active_signature: usize,
+    pub active_parameter: Option<usize>,
 }
 
 /// Event produced by file tree rendering (one per frame at most).


### PR DESCRIPTION
## v0.4.0 — Editor polish, AI-ready, theme switcher

### Settings
- **Keybindings**: click a shortcut to record a new chord, with conflict detection, per-row clear, and reset-to-defaults.
- **Appearance**: Dark / Light / High Contrast theme presets that apply + persist live (\`~/.berrycode/theme.json\`).

### LSP
- **Signature help** popup with active-parameter highlighting + inline docs. Auto-triggers on \`(\` / \`,\`, manual via Cmd+Shift+Space.
- **Completion popup** keyboard nav (↑/↓, PageUp/PageDown), Tab/Enter acceptance is consumed before TextEdit (no stray newline), click-to-accept now respects the actual popup position.
- Auto-trigger on IME-committed text so 日本語 入力後にも候補が出る.

### Editor / IME
- Gutter (line numbers, fold icons, breakpoints) re-anchored on the galley position — fixes a regression introduced by the egui 0.33 \`response.rect\` semantics change.
- Auto-close brackets gated on actual \`Event::Text\` so Cmd+Z no longer leaves orphan \`}\` from undo replays.
- \`text.insert\` / \`text.insert_str\` convert char→byte index so CJK before the cursor doesn't break auto-close / auto-indent.
- Selection background alpha bumped so IME preedit is visibly distinct from committed text.

## Test plan
- [x] \`cargo check\` clean
- [x] \`cargo test --lib\` — 476/476 pass
- [x] Manual: rebind a shortcut in Settings, restart, persists
- [x] Manual: switch theme preset to Light + High Contrast, restart, persists
- [x] Manual: \`Vec3::new(\` shows signature help with active param underlined
- [x] Manual: type a function name, ↑↓ navigate completions, Enter inserts (no newline)
- [x] Manual: \`{ Cmd+Z\` no longer leaves orphan braces
- [x] Manual: type 日本語, completion list still pops