### PR TITLE
style: unify UI palette via ui_colors constants

### DIFF
--- a/berrycode/src/app/button_style.rs
+++ b/berrycode/src/app/button_style.rs
@@ -148,7 +148,7 @@ fn icon_label_job(
         &format!("  {label}"),
         0.0,
         egui::TextFormat {
-            font_id: egui::FontId::proportional(13.0),
+            font_id: egui::FontId::proportional(12.0),
             color: text_color,
             ..Default::default()
         },
@@ -163,7 +163,7 @@ fn icon_label_job(
 pub fn icon_button(ui: &mut egui::Ui, glyph: &str, tooltip: &str) -> egui::Response {
     let text = egui::RichText::new(glyph)
         .family(egui::FontFamily::Name("codicon".into()))
-        .size(13.0);
+        .size(12.0);
     let response = ui.add_sized(
         egui::vec2(22.0, 22.0),
         egui::Button::new(text).min_size(egui::vec2(22.0, 22.0)),

--- a/berrycode/src/app/dock.rs
+++ b/berrycode/src/app/dock.rs
@@ -5,6 +5,7 @@
 //! switch between tools in the same panel area.
 
 use crate::app::types::DiagnosticSeverity;
+use crate::app::ui_colors;
 use crate::app::BerryCodeApp;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,7 +72,7 @@ impl BerryCodeApp {
             .min_height(100.0)
             .frame(
                 egui::Frame::NONE
-                    .fill(egui::Color32::from_rgb(30, 31, 34))
+                    .fill(ui_colors::SIDEBAR_BG)
                     .inner_margin(egui::Margin::same(4)),
             )
             .show(ctx, |ui| {

--- a/berrycode/src/app/editor.rs
+++ b/berrycode/src/app/editor.rs
@@ -46,13 +46,13 @@ impl BerryCodeApp {
                 // Tab bar (VS Code style)
                 let mut tab_to_close: Option<usize> = None;
 
-                let tab_bar_bg = egui::Color32::from_rgb(37, 37, 38); // #252526
-                let tab_active_bg = egui::Color32::from_rgb(30, 30, 30); // #1E1E1E
-                let tab_inactive_bg = egui::Color32::from_rgb(45, 45, 46); // #2D2D2E
-                let tab_border = egui::Color32::from_rgb(37, 37, 38);
-                let tab_active_indicator = super::component_colors::ACCENT; // #007ACC
-                let tab_text_active = egui::Color32::from_rgb(255, 255, 255);
-                let tab_text_inactive = egui::Color32::from_rgb(150, 150, 150);
+                let tab_bar_bg = ui_colors::SIDEBAR_BG;
+                let tab_active_bg = ui_colors::EDITOR_BG;
+                let tab_inactive_bg = ui_colors::SIDEBAR_BG;
+                let tab_border = ui_colors::PANEL_BORDER;
+                let tab_active_indicator = ui_colors::ACCENT;
+                let tab_text_active = ui_colors::TEXT_DEFAULT;
+                let tab_text_inactive = ui_colors::TEXT_MUTED;
 
                 // Tab bar background
                 let tab_bar_rect = egui::Rect::from_min_size(

--- a/berrycode/src/app/header.rs
+++ b/berrycode/src/app/header.rs
@@ -19,25 +19,24 @@ impl BerryCodeApp {
                 ui.horizontal(|ui| {
                     ui.add_space(4.0);
 
-                    // Purple tab with project info
+                    // Compact project switcher, styled like VS Code's title bar command area.
                     let tab_rect_size = egui::vec2(160.0, 24.0);
                     let (tab_rect, _response) =
                         ui.allocate_exact_size(tab_rect_size, egui::Sense::click());
 
-                    // Draw purple background
-                    ui.painter().rect_filled(
+                    ui.painter()
+                        .rect_filled(tab_rect, 3.0, egui::Color32::from_rgb(71, 71, 71));
+                    ui.painter().rect_stroke(
                         tab_rect,
-                        4.0,                                   // Rounded corners
-                        egui::Color32::from_rgb(126, 89, 161), // Purple #7E59A1
+                        3.0,
+                        egui::Stroke::new(1.0, ui_colors::CONTROL_BORDER),
+                        egui::StrokeKind::Inside,
                     );
 
                     // Draw badge with "0"
                     let badge_center = egui::pos2(tab_rect.left() + 16.0, tab_rect.center().y);
-                    ui.painter().circle_filled(
-                        badge_center,
-                        9.0,
-                        egui::Color32::from_rgba_premultiplied(255, 255, 255, 60),
-                    );
+                    ui.painter()
+                        .circle_filled(badge_center, 9.0, ui_colors::ACCENT);
                     ui.painter().text(
                         badge_center,
                         egui::Align2::CENTER_CENTER,
@@ -55,7 +54,7 @@ impl BerryCodeApp {
                         egui::Align2::LEFT_CENTER,
                         project_name,
                         egui::FontId::proportional(12.0),
-                        egui::Color32::WHITE,
+                        ui_colors::TEXT_DEFAULT,
                     );
 
                     // Dropdown arrow
@@ -65,7 +64,7 @@ impl BerryCodeApp {
                         egui::Align2::CENTER_CENTER,
                         "▼",
                         egui::FontId::proportional(9.0),
-                        egui::Color32::from_rgb(200, 200, 200),
+                        ui_colors::TEXT_MUTED,
                     );
 
                     ui.add_space(16.0);
@@ -283,25 +282,19 @@ impl BerryCodeApp {
             .resizable(false)
             .frame(
                 egui::Frame::NONE
-                    .fill(ui_colors::SIDEBAR_BG) // #191A1C
+                    .fill(ui_colors::ACTIVITY_BAR_BG)
                     .inner_margin(egui::Margin::same(4)),
             )
             .show(ctx, |ui| {
                 ui.vertical_centered(|ui| {
                     ui.add_space(8.0);
 
-                    // Increase icon size for Activity Bar
-                    ui.style_mut().text_styles.insert(
-                        egui::TextStyle::Button,
-                        egui::FontId::proportional(20.0), // Increased from default
-                    );
-
                     let icon_size = 24.0;
                     let btn_size = egui::vec2(40.0, 40.0);
-                    let active_bar_color = egui::Color32::from_rgb(255, 255, 255);
-                    let icon_active = egui::Color32::from_rgb(255, 255, 255);
-                    let icon_inactive = egui::Color32::from_rgb(120, 120, 120);
-                    let hover_bg = egui::Color32::from_rgb(45, 47, 50);
+                    let active_bar_color = ui_colors::TEXT_DEFAULT;
+                    let icon_active = ui_colors::TEXT_DEFAULT;
+                    let icon_inactive = ui_colors::TEXT_MUTED;
+                    let hover_bg = ui_colors::HOVER_BG;
 
                     for panel in MAIN_PANELS {
                         let is_selected = self.active_panel == panel.variant;

--- a/berrycode/src/app/mod.rs
+++ b/berrycode/src/app/mod.rs
@@ -298,25 +298,32 @@ pub(crate) mod syntax_colors {
 pub(crate) mod ui_colors {
     use egui::Color32;
 
-    pub const SIDEBAR_BG: Color32 = Color32::from_rgb(25, 26, 28); // #191A1C Dark Gray
-    pub const EDITOR_BG: Color32 = Color32::from_rgb(25, 26, 28); // #191A1C Dark Gray
-    pub const TOP_BAR_BG: Color32 = Color32::from_rgb(48, 49, 52); // #303134 toolbar
-    pub const TEXT_DEFAULT: Color32 = Color32::from_rgb(212, 212, 212); // #D4D4D4 Light Gray
-    pub const TEXT_MUTED: Color32 = Color32::from_rgb(154, 157, 168); // subdued labels
-    pub const BORDER: Color32 = Color32::from_rgb(54, 57, 59); // #36393B Medium Gray
-    pub const PANEL_BORDER: Color32 = Color32::from_rgb(36, 38, 42); // #24262A splitters
-    pub const CONTROL_BG: Color32 = Color32::from_rgb(32, 34, 39); // #202227 buttons/inputs
-    pub const CONTROL_BORDER: Color32 = Color32::from_rgb(54, 57, 66); // #363942
+    pub const EDITOR_BG: Color32 = Color32::from_rgb(25, 26, 28); // #191A1C
+    pub const SIDEBAR_BG: Color32 = Color32::from_rgb(25, 26, 28); // #191A1C
+    pub const ACTIVITY_BAR_BG: Color32 = Color32::from_rgb(25, 26, 28); // #191A1C
+    pub const TOP_BAR_BG: Color32 = Color32::from_rgb(48, 49, 52); // #303134
+    pub const STATUS_BAR_BG: Color32 = Color32::from_rgb(25, 26, 28); // #191A1C
+    pub const TEXT_DEFAULT: Color32 = Color32::from_rgb(212, 212, 212); // #D4D4D4
+    pub const TEXT_MUTED: Color32 = Color32::from_rgb(153, 153, 153); // #999999
+    pub const BORDER: Color32 = Color32::from_rgb(60, 60, 60); // #3C3C3C
+    pub const PANEL_BORDER: Color32 = Color32::from_rgb(43, 43, 43); // #2B2B2B
+    pub const CONTROL_BG: Color32 = Color32::from_rgb(60, 60, 60); // #3C3C3C
+    pub const CONTROL_BORDER: Color32 = Color32::from_rgb(86, 86, 86); // #565656
+    pub const HOVER_BG: Color32 = Color32::from_rgb(45, 45, 45); // #2D2D2D
+    pub const ACTIVE_BG: Color32 = Color32::from_rgb(55, 55, 61); // #37373D
+    pub const ACCENT: Color32 = Color32::from_rgb(0, 122, 204); // #007ACC
+    pub const ACCENT_HOVER: Color32 = Color32::from_rgb(17, 119, 187); // #1177BB
+    pub const FOCUS_BORDER: Color32 = Color32::from_rgb(0, 127, 212); // #007FD4
 
     // VS Code-style settings palette
-    pub const SETTINGS_NAV_BG: Color32 = Color32::from_rgb(30, 30, 32); // panel column
-    pub const SETTINGS_BG: Color32 = Color32::from_rgb(36, 37, 41); // main scroll area
-    pub const SETTINGS_SEARCH_BG: Color32 = Color32::from_rgb(50, 52, 58); // search input
-    pub const SETTINGS_DESC: Color32 = Color32::from_rgb(150, 152, 160); // description text
-    pub const SETTINGS_HINT: Color32 = Color32::from_rgb(120, 122, 130); // tertiary hint
-    pub const SETTINGS_HEADER: Color32 = Color32::from_rgb(220, 222, 230); // section header
-    pub const SETTINGS_CARD_BORDER: Color32 = Color32::from_rgb(60, 62, 68);
-    pub const SETTINGS_ACCENT: Color32 = Color32::from_rgb(99, 139, 255);
+    pub const SETTINGS_NAV_BG: Color32 = SIDEBAR_BG;
+    pub const SETTINGS_BG: Color32 = EDITOR_BG;
+    pub const SETTINGS_SEARCH_BG: Color32 = CONTROL_BG;
+    pub const SETTINGS_DESC: Color32 = TEXT_MUTED;
+    pub const SETTINGS_HINT: Color32 = Color32::from_rgb(128, 128, 128);
+    pub const SETTINGS_HEADER: Color32 = TEXT_DEFAULT;
+    pub const SETTINGS_CARD_BORDER: Color32 = BORDER;
+    pub const SETTINGS_ACCENT: Color32 = ACCENT;
 }
 
 // ===== Component Color Palette =====
@@ -326,19 +333,19 @@ pub(crate) mod ui_colors {
 pub(crate) mod component_colors {
     use egui::Color32;
     // VS Code accent blue
-    pub const ACCENT: Color32 = Color32::from_rgb(0, 122, 204);
+    pub const ACCENT: Color32 = super::ui_colors::ACCENT;
     // Tab colors
-    pub const TAB_ACTIVE: Color32 = Color32::from_rgb(255, 255, 255);
-    pub const TAB_INACTIVE: Color32 = Color32::from_rgb(130, 130, 130);
+    pub const TAB_ACTIVE: Color32 = super::ui_colors::TEXT_DEFAULT;
+    pub const TAB_INACTIVE: Color32 = super::ui_colors::TEXT_MUTED;
     // Button colors
-    pub const BUTTON_TEXT: Color32 = Color32::from_rgb(200, 200, 200);
-    pub const BUTTON_BG: Color32 = Color32::from_rgb(45, 45, 48);
+    pub const BUTTON_TEXT: Color32 = super::ui_colors::TEXT_DEFAULT;
+    pub const BUTTON_BG: Color32 = super::ui_colors::CONTROL_BG;
     // Hover
-    pub const HOVER_BG: Color32 = Color32::from_rgb(42, 45, 46);
+    pub const HOVER_BG: Color32 = super::ui_colors::HOVER_BG;
     // Input
-    pub const INPUT_BG: Color32 = Color32::from_rgb(28, 29, 34);
+    pub const INPUT_BG: Color32 = super::ui_colors::CONTROL_BG;
     // Dim text
-    pub const TEXT_DIM: Color32 = Color32::from_rgb(110, 115, 130);
+    pub const TEXT_DIM: Color32 = super::ui_colors::TEXT_MUTED;
 }
 
 // ===== File Icon Color Palette =====
@@ -1094,43 +1101,39 @@ impl BerryCodeApp {
         crate::app::i18n::t(self.ui_language, key)
     }
 
-    /// Apply the BerryCode egui style — IntelliJ-inspired dark theme
+    /// Apply the BerryCode egui style — VS Code Dark+ inspired theme.
     pub fn setup_egui_style(ctx: &egui::Context) {
         let mut style = egui::Style::default();
         let mut visuals = egui::Visuals::dark();
 
-        // === Colors === (VS Code Dark+ inspired)
-        let bg_dark = egui::Color32::from_rgb(30, 30, 30); // editor.background #1E1E1E
-        let bg_panel = egui::Color32::from_rgb(58, 61, 65); // button.secondaryBackground #3A3D41
-        let bg_input = egui::Color32::from_rgb(60, 60, 60); // input.background #3C3C3C
-        let bg_hover = egui::Color32::from_rgb(69, 73, 78); // button.secondaryHoverBackground #45494E
-        let bg_active = egui::Color32::from_rgb(45, 47, 50); // pressed (slightly darker than rest)
-                                                             // Selection bg uses RGBA with alpha so the underlying text remains
-                                                             // legible during IME preedit (egui paints selection over the glyphs).
-                                                             // Premultiplied alpha: ~30% opacity = (rgb * 0.3, alpha 76).
-        let bg_selected = egui::Color32::from_rgba_premultiplied(20, 40, 70, 130);
-        let border = egui::Color32::from_rgba_premultiplied(0, 0, 0, 0); // VS Code: no borders by default
-        let border_focus = egui::Color32::from_rgb(0, 127, 212); // VS Code focusBorder #007FD4
-        let text = egui::Color32::from_rgb(205, 207, 213); // primary text
-        let _text_dim = egui::Color32::from_rgb(140, 143, 150); // secondary text
+        let bg_dark = ui_colors::EDITOR_BG;
+        let bg_panel = ui_colors::SIDEBAR_BG;
+        let bg_input = ui_colors::CONTROL_BG;
+        let bg_hover = ui_colors::HOVER_BG;
+        let bg_active = ui_colors::ACTIVE_BG;
+        let bg_selected = egui::Color32::from_rgba_premultiplied(9, 71, 113, 180);
+        let border = ui_colors::BORDER;
+        let border_focus = ui_colors::FOCUS_BORDER;
+        let text = ui_colors::TEXT_DEFAULT;
 
         visuals.override_text_color = None;
         visuals.window_fill = bg_panel;
         visuals.panel_fill = bg_dark;
         visuals.extreme_bg_color = bg_input;
-        visuals.code_bg_color = egui::Color32::from_rgb(35, 36, 40);
-        visuals.faint_bg_color = egui::Color32::from_rgb(38, 40, 43);
+        visuals.code_bg_color = bg_dark;
+        visuals.faint_bg_color = ui_colors::HOVER_BG;
+        visuals.hyperlink_color = ui_colors::ACCENT_HOVER;
 
         // Window
-        visuals.window_stroke = egui::Stroke::new(1.0, border);
+        visuals.window_stroke = egui::Stroke::new(1.0, ui_colors::PANEL_BORDER);
         visuals.window_shadow = egui::epaint::Shadow {
-            offset: [0, 4],
-            blur: 12,
+            offset: [0, 8],
+            blur: 24,
             spread: 0,
-            color: egui::Color32::from_black_alpha(80),
+            color: egui::Color32::from_black_alpha(100),
         };
-        visuals.window_corner_radius = egui::CornerRadius::same(8);
-        visuals.menu_corner_radius = egui::CornerRadius::same(6);
+        visuals.window_corner_radius = egui::CornerRadius::same(4);
+        visuals.menu_corner_radius = egui::CornerRadius::same(3);
 
         // Selection — `selection.stroke.color` is misleadingly named: egui
         // uses it to *override* the glyph color of the selected text, so it
@@ -1140,22 +1143,21 @@ impl BerryCodeApp {
         visuals.selection.stroke = egui::Stroke::new(0.0, text);
 
         // Text cursor
-        visuals.text_cursor.stroke.color = egui::Color32::from_rgb(180, 190, 220);
+        visuals.text_cursor.stroke.color = egui::Color32::from_rgb(174, 175, 173);
 
         // === Widget Styles ===
 
         // Non-interactive (labels, separators)
         visuals.widgets.noninteractive.bg_fill = bg_dark;
         visuals.widgets.noninteractive.weak_bg_fill = bg_dark;
-        visuals.widgets.noninteractive.bg_stroke =
-            egui::Stroke::new(0.0, egui::Color32::TRANSPARENT);
+        visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0, ui_colors::PANEL_BORDER);
         visuals.widgets.noninteractive.fg_stroke = egui::Stroke::new(1.0, text);
         visuals.widgets.noninteractive.corner_radius = egui::CornerRadius::same(2);
 
         // Inactive (buttons, checkboxes at rest)
         visuals.widgets.inactive.bg_fill = bg_panel;
         visuals.widgets.inactive.weak_bg_fill = bg_panel;
-        visuals.widgets.inactive.bg_stroke = egui::Stroke::NONE;
+        visuals.widgets.inactive.bg_stroke = egui::Stroke::new(1.0, border);
         visuals.widgets.inactive.fg_stroke = egui::Stroke::new(1.0, text);
         visuals.widgets.inactive.corner_radius = egui::CornerRadius::same(2);
         visuals.widgets.inactive.expansion = 0.0;
@@ -1163,7 +1165,7 @@ impl BerryCodeApp {
         // Hovered
         visuals.widgets.hovered.bg_fill = bg_hover;
         visuals.widgets.hovered.weak_bg_fill = bg_hover;
-        visuals.widgets.hovered.bg_stroke = egui::Stroke::NONE;
+        visuals.widgets.hovered.bg_stroke = egui::Stroke::new(1.0, ui_colors::CONTROL_BORDER);
         visuals.widgets.hovered.fg_stroke = egui::Stroke::new(1.0, egui::Color32::WHITE);
         visuals.widgets.hovered.corner_radius = egui::CornerRadius::same(2);
         visuals.widgets.hovered.expansion = 0.0;
@@ -1187,7 +1189,7 @@ impl BerryCodeApp {
         visuals.popup_shadow = egui::epaint::Shadow {
             offset: [0, 6],
             blur: 16,
-            spread: 2,
+            spread: 0,
             color: egui::Color32::from_black_alpha(100),
         };
 
@@ -1195,16 +1197,15 @@ impl BerryCodeApp {
         visuals.striped = true;
 
         // Separator
-        visuals.widgets.noninteractive.bg_stroke =
-            egui::Stroke::new(1.0, egui::Color32::from_rgb(45, 47, 50));
+        visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0, ui_colors::PANEL_BORDER);
 
         style.visuals = visuals;
 
         // === Spacing ===
-        style.spacing.item_spacing = egui::vec2(8.0, 6.0); // more breathing room
+        style.spacing.item_spacing = egui::vec2(8.0, 5.0);
         style.spacing.button_padding = egui::vec2(8.0, 3.0); // VS Code: compact
-        style.spacing.window_margin = egui::Margin::same(12); // window inner padding
-        style.spacing.menu_margin = egui::Margin::same(8);
+        style.spacing.window_margin = egui::Margin::same(8);
+        style.spacing.menu_margin = egui::Margin::same(6);
         style.spacing.indent = 18.0; // tree indent
                                      // Keep resize handles and splitters slim and consistent across
                                      // Explorer/Search/AI/Inspector side panels.
@@ -1220,23 +1221,26 @@ impl BerryCodeApp {
             ..Default::default()
         };
 
-        // === Text (even pixel sizes for crisp rendering) ===
+        // === Text ===
+        // VS Code keeps its chrome compact: 13px body text, 12px controls,
+        // 11px secondary labels. Panels can still opt into larger text for
+        // true document/editor content, but the app shell starts here.
         use egui::FontId;
         style
             .text_styles
-            .insert(egui::TextStyle::Heading, FontId::proportional(18.0));
+            .insert(egui::TextStyle::Heading, FontId::proportional(16.0));
         style
             .text_styles
-            .insert(egui::TextStyle::Body, FontId::proportional(14.0));
+            .insert(egui::TextStyle::Body, FontId::proportional(13.0));
         style
             .text_styles
-            .insert(egui::TextStyle::Small, FontId::proportional(12.0));
+            .insert(egui::TextStyle::Small, FontId::proportional(11.0));
         style
             .text_styles
-            .insert(egui::TextStyle::Button, FontId::proportional(13.0));
+            .insert(egui::TextStyle::Button, FontId::proportional(12.0));
         style
             .text_styles
-            .insert(egui::TextStyle::Monospace, FontId::monospace(14.0));
+            .insert(egui::TextStyle::Monospace, FontId::monospace(13.0));
 
         // === Interaction ===
         style.interaction.show_tooltips_only_when_still = false;
@@ -1464,7 +1468,7 @@ impl BerryCodeApp {
     /// Render the project picker screen (shown when no project is loaded)
     pub(crate) fn render_project_picker(&mut self, ctx: &egui::Context) {
         egui::CentralPanel::default()
-            .frame(egui::Frame::NONE.fill(egui::Color32::from_rgb(25, 27, 31)))
+            .frame(egui::Frame::NONE.fill(ui_colors::EDITOR_BG))
             .show(ctx, |ui| {
                 ui.vertical_centered(|ui| {
                     ui.add_space(80.0);
@@ -1473,7 +1477,7 @@ impl BerryCodeApp {
                     ui.label(
                         egui::RichText::new("BerryCode")
                             .size(48.0)
-                            .color(egui::Color32::from_rgb(126, 89, 161))
+                            .color(ui_colors::TEXT_DEFAULT)
                             .strong(),
                     );
                     ui.label(

--- a/berrycode/src/app/scene_editor/hierarchy.rs
+++ b/berrycode/src/app/scene_editor/hierarchy.rs
@@ -3,6 +3,7 @@
 
 use super::model::*;
 use crate::app::button_style::{button_with_icon, glyph, icon_button, primary_button};
+use crate::app::ui_colors;
 use crate::app::BerryCodeApp;
 
 impl BerryCodeApp {
@@ -49,12 +50,12 @@ impl BerryCodeApp {
         // tabs so the two surfaces feel like one IDE: dark active bg,
         // a slightly lighter inactive bg, ACCENT-coloured 2px bottom
         // bar marking the active one.
-        let tab_active_bg = egui::Color32::from_rgb(30, 30, 30);
-        let tab_inactive_bg = egui::Color32::from_rgb(45, 45, 46);
-        let tab_border = egui::Color32::from_rgb(37, 37, 38);
-        let tab_active_indicator = egui::Color32::from_rgb(0, 122, 204);
-        let tab_text_active = egui::Color32::from_rgb(255, 255, 255);
-        let tab_text_inactive = egui::Color32::from_gray(180);
+        let tab_active_bg = ui_colors::EDITOR_BG;
+        let tab_inactive_bg = ui_colors::SIDEBAR_BG;
+        let tab_border = ui_colors::PANEL_BORDER;
+        let tab_active_indicator = ui_colors::ACCENT;
+        let tab_text_active = ui_colors::TEXT_DEFAULT;
+        let tab_text_inactive = ui_colors::TEXT_MUTED;
         // Pre-compute display labels with disambiguation: when two tabs
         // share the same base label, prefix the one with a different
         // path with its parent directory ("scenes/scene" vs
@@ -100,11 +101,11 @@ impl BerryCodeApp {
 
                 let frame = egui::Frame::NONE
                     .fill(bg)
-                    .inner_margin(egui::Margin::symmetric(10, 5))
+                    .inner_margin(egui::Margin::symmetric(10, 4))
                     .stroke(egui::Stroke::new(1.0, tab_border));
                 let resp = frame.show(ui, |ui| {
                     ui.horizontal(|ui| {
-                        ui.spacing_mut().item_spacing.x = 6.0;
+                        ui.spacing_mut().item_spacing.x = 5.0;
                         // Modified dot — VS Code shows a filled circle
                         // in the close-button slot when the file has
                         // unsaved edits; we emulate that with a small
@@ -132,7 +133,20 @@ impl BerryCodeApp {
                         // panel never ends up with zero tabs (it
                         // injects a fresh blank one if you close the
                         // last).
-                        if icon_button(ui, glyph::CLOSE, "Close scene").clicked() {
+                        let close_text = egui::RichText::new(glyph::CLOSE)
+                            .size(11.0)
+                            .color(text_color)
+                            .family(egui::FontFamily::Name("codicon".into()));
+                        if ui
+                            .add_sized(
+                                egui::vec2(16.0, 16.0),
+                                egui::Button::new(close_text)
+                                    .frame(false)
+                                    .min_size(egui::vec2(16.0, 16.0)),
+                            )
+                            .on_hover_text("Close scene")
+                            .clicked()
+                        {
                             close_tab = Some(i);
                         }
                     });

--- a/berrycode/src/app/search.rs
+++ b/berrycode/src/app/search.rs
@@ -1,6 +1,7 @@
 //! Search panel, search dialog, and search operations
 
 use super::types::SearchMatch;
+use super::ui_colors;
 use super::BerryCodeApp;
 use crate::buffer::TextBuffer;
 use crate::native;
@@ -13,13 +14,14 @@ impl BerryCodeApp {
         let text_primary = egui::Color32::from_rgb(204, 204, 204);
         let text_muted = egui::Color32::from_rgb(133, 133, 133);
         let text_dim = egui::Color32::from_rgb(110, 110, 110);
-        let input_bg = egui::Color32::from_rgb(60, 60, 60);
+        let input_bg = ui_colors::CONTROL_BG;
         // VS Code's `input.border` is invisible by default — the box is
         // distinguished from the panel only by the slightly lighter fill.
         let input_border = egui::Color32::TRANSPARENT;
-        let input_border_focus = egui::Color32::from_rgb(0, 122, 204);
-        let toggle_active_bg = egui::Color32::from_rgba_unmultiplied(99, 122, 168, 80);
-        let toggle_active_border = egui::Color32::from_rgb(99, 122, 168);
+        let input_border_focus = ui_colors::FOCUS_BORDER;
+        let toggle_active_bg = ui_colors::ACTIVE_BG;
+        let toggle_hover_bg = ui_colors::HOVER_BG;
+        let toggle_active_border = ui_colors::FOCUS_BORDER;
         let match_highlight = egui::Color32::from_rgba_unmultiplied(234, 92, 0, 90);
         let row_hover_bg = egui::Color32::from_rgba_unmultiplied(255, 255, 255, 12);
 
@@ -128,13 +130,14 @@ impl BerryCodeApp {
             // Single rounded frame containing the text input AND the three
             // option toggles (Aa / ab / .*), exactly like VS Code.
             let frame_stroke_color = input_border;
+            let mut search_input_focused = false;
             let row_frame = egui::Frame::NONE
                 .fill(input_bg)
                 .stroke(egui::Stroke::new(1.0, frame_stroke_color))
                 .corner_radius(egui::CornerRadius::same(2))
-                .inner_margin(egui::Margin::symmetric(3, 1));
+                .inner_margin(egui::Margin::symmetric(6, 2));
 
-            row_frame.show(ui, |ui| {
+            let row_response = row_frame.show(ui, |ui| {
                 // VS Code layout: toggles right-aligned, TextEdit fills the
                 // left remainder. Using `right_to_left` instead of giving
                 // the TextEdit a manual `desired_width(available - toggles)`
@@ -143,30 +146,44 @@ impl BerryCodeApp {
                 // SidePanel resize handle and blocks horizontal resizing.
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.spacing_mut().item_spacing.x = 2.0;
-                    let toggle_w = 20.0;
 
                     // Helper: render one inline toggle. Placed in
                     // right_to_left order so on-screen it reads
                     // `[Aa] [ab] [.*]` left-to-right.
                     let toggle = |ui: &mut egui::Ui, label: &str, state: &mut bool, hover: &str| {
-                        let (bg, border) = if *state {
-                            (toggle_active_bg, toggle_active_border)
+                        let size = egui::vec2(22.0, 20.0);
+                        let (rect, response) = ui.allocate_exact_size(size, egui::Sense::click());
+                        let bg = if *state {
+                            toggle_active_bg
+                        } else if response.hovered() {
+                            toggle_hover_bg
                         } else {
-                            (egui::Color32::TRANSPARENT, egui::Color32::TRANSPARENT)
+                            egui::Color32::TRANSPARENT
                         };
-                        let color = if *state {
-                            egui::Color32::from_rgb(220, 220, 220)
+                        let border = if *state {
+                            toggle_active_border
                         } else {
-                            text_muted
+                            egui::Color32::TRANSPARENT
                         };
-                        let btn = ui.add_sized(
-                            egui::vec2(toggle_w, 20.0),
-                            egui::Button::new(egui::RichText::new(label).size(11.0).color(color))
-                                .fill(bg)
-                                .stroke(egui::Stroke::new(1.0, border))
-                                .corner_radius(egui::CornerRadius::same(2)),
+                        let color = if *state { text_primary } else { text_muted };
+                        if bg != egui::Color32::TRANSPARENT || border != egui::Color32::TRANSPARENT
+                        {
+                            ui.painter().rect(
+                                rect,
+                                egui::CornerRadius::same(2),
+                                bg,
+                                egui::Stroke::new(1.0, border),
+                                egui::StrokeKind::Inside,
+                            );
+                        }
+                        ui.painter().text(
+                            rect.center(),
+                            egui::Align2::CENTER_CENTER,
+                            label,
+                            egui::FontId::proportional(10.5),
+                            color,
                         );
-                        if btn.on_hover_text(hover).clicked() {
+                        if response.on_hover_text(hover).clicked() {
                             *state = !*state;
                         }
                     };
@@ -191,19 +208,20 @@ impl BerryCodeApp {
                             .text_color(text_primary)
                             .hint_text(egui::RichText::new("Search").color(text_dim)),
                     );
-                    if response.has_focus() {
-                        ui.painter().rect_stroke(
-                            response.rect.expand(2.0),
-                            egui::CornerRadius::same(2),
-                            egui::Stroke::new(1.0, input_border_focus),
-                            egui::StrokeKind::Outside,
-                        );
-                    }
+                    search_input_focused = response.has_focus();
                     if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                         do_search = true;
                     }
                 });
             });
+            if search_input_focused {
+                ui.painter().rect_stroke(
+                    row_response.response.rect,
+                    egui::CornerRadius::same(2),
+                    egui::Stroke::new(1.0, input_border_focus),
+                    egui::StrokeKind::Inside,
+                );
+            }
         });
 
         // === Replace input row (only when chevron is expanded) ===
@@ -214,13 +232,14 @@ impl BerryCodeApp {
                 // Spacer matching the chevron column width above (14px).
                 ui.add_space(14.0);
 
+                let mut replace_input_focused = false;
                 let row_frame = egui::Frame::NONE
                     .fill(input_bg)
                     .stroke(egui::Stroke::new(1.0, input_border))
                     .corner_radius(egui::CornerRadius::same(2))
-                    .inner_margin(egui::Margin::symmetric(3, 1));
+                    .inner_margin(egui::Margin::symmetric(6, 2));
 
-                row_frame.show(ui, |ui| {
+                let row_response = row_frame.show(ui, |ui| {
                     // Same pattern as the search input row above:
                     // right_to_left places the Replace-All button on the
                     // right, TextEdit fills the rest. Avoids overflowing
@@ -247,16 +266,17 @@ impl BerryCodeApp {
                                 .text_color(text_primary)
                                 .hint_text(egui::RichText::new("Replace").color(text_dim)),
                         );
-                        if response.has_focus() {
-                            ui.painter().rect_stroke(
-                                response.rect.expand(2.0),
-                                egui::CornerRadius::same(2),
-                                egui::Stroke::new(1.0, input_border_focus),
-                                egui::StrokeKind::Outside,
-                            );
-                        }
+                        replace_input_focused = response.has_focus();
                     });
                 });
+                if replace_input_focused {
+                    ui.painter().rect_stroke(
+                        row_response.response.rect,
+                        egui::CornerRadius::same(2),
+                        egui::Stroke::new(1.0, input_border_focus),
+                        egui::StrokeKind::Inside,
+                    );
+                }
             });
         }
 

--- a/berrycode/src/app/settings.rs
+++ b/berrycode/src/app/settings.rs
@@ -18,7 +18,7 @@ impl BerryCodeApp {
             ui.add_space(4.0);
             ui.label(
                 egui::RichText::new("Settings")
-                    .size(18.0)
+                    .size(16.0)
                     .color(ui_colors::SETTINGS_HEADER)
                     .strong(),
             );
@@ -287,7 +287,7 @@ impl BerryCodeApp {
 
         ui.label(
             egui::RichText::new("AI Providers")
-                .size(20.0)
+                .size(16.0)
                 .color(ui_colors::SETTINGS_HEADER)
                 .strong(),
         );
@@ -402,7 +402,7 @@ impl BerryCodeApp {
         ui.add_space(8.0);
         ui.label(
             egui::RichText::new("Model selection")
-                .size(15.0)
+                .size(13.0)
                 .color(ui_colors::SETTINGS_HEADER)
                 .strong(),
         );
@@ -918,7 +918,7 @@ impl BerryCodeApp {
                 ui.add_space(6.0);
                 ui.label(
                     egui::RichText::new(format!("${:.2}", t.cost_usd))
-                        .size(22.0)
+                        .size(18.0)
                         .color(egui::Color32::WHITE),
                 );
                 ui.add_space(4.0);

--- a/berrycode/src/app/status_bar.rs
+++ b/berrycode/src/app/status_bar.rs
@@ -10,7 +10,7 @@ impl BerryCodeApp {
             .exact_height(22.0)
             .frame(
                 egui::Frame::NONE
-                    .fill(ui_colors::SIDEBAR_BG)
+                    .fill(ui_colors::STATUS_BAR_BG)
                     .inner_margin(egui::Margin::symmetric(8, 2)),
             )
             .show(ctx, |ui| {
@@ -23,13 +23,8 @@ impl BerryCodeApp {
                     ui.spacing_mut().item_spacing.x = 8.0;
 
                     // Left side
-                    let lsp_color = if self.lsp_connected {
-                        egui::Color32::from_rgb(80, 200, 80)
-                    } else {
-                        egui::Color32::from_rgb(180, 80, 80)
-                    };
                     let lsp_label = if self.lsp_connected { "LSP" } else { "LSP off" };
-                    ui.colored_label(lsp_color, lsp_label);
+                    ui.label(egui::RichText::new(lsp_label).color(ui_colors::TEXT_DEFAULT));
 
                     let rs_diag_count =
                         super::utils::filter_rust_diagnostics(&self.lsp_diagnostics).len();


### PR DESCRIPTION
## Summary
- Replace ad-hoc `Color32` literals across header, editor tabs, dock, status bar, search, scene editor hierarchy, and settings with `ui_colors` constants so the VS Code Dark+ palette is sourced from one place.
- Add new palette constants (`ACTIVITY_BAR_BG`, `STATUS_BAR_BG`, `HOVER_BG`, `ACTIVE_BG`, `ACCENT`, `ACCENT_HOVER`, `FOCUS_BORDER`) and re-route `component_colors` and the settings palette through them.
- Tighten chrome text sizing to VS Code defaults (13px body, 12px controls, 11px small, 16px headings) and rebuild the search-option toggles (`Aa` / `ab` / `.*`) as custom-painted chips that hover and activate consistently.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo check -p berrycode\`
- [x] Launch \`cargo run --bin berrycode\` and confirm header tab, activity bar, editor tabs, scene editor tabs, search panel, settings, and status bar render with the unified palette
- [x] Verify search panel toggles still activate/deactivate and focus ring is visible on Search/Replace inputs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to UI styling/theme constants and minor search-toggle/focus rendering, with no impact to core app logic or data handling.
> 
> **Overview**
> Unifies UI styling by routing previously hard-coded `Color32` values across the header, editor tabs, dock/tool panel, status bar, scene hierarchy tabs, search panel, settings, and project picker through the shared `ui_colors` palette (including new constants like `ACTIVITY_BAR_BG`, `STATUS_BAR_BG`, `HOVER_BG`, `ACTIVE_BG`, `ACCENT*`, and `FOCUS_BORDER`).
> 
> Updates the global egui theme to better match VS Code Dark+ (adjusted borders/shadows/selection colors) and tightens default text sizing for the app chrome. Refines several widgets: codicon button/icon sizing, the scene hierarchy close button, and reworks search option toggles and input focus rings to use consistent hover/active styling and inside-stroke focus rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e1f1a343bcc67246fb9984cdf8c80f6932e860a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->