### PR TITLE
Feat: Move AI to rust feature

### DIFF
--- a/berrycode/Cargo.toml
+++ b/berrycode/Cargo.toml
@@ -136,8 +136,9 @@ lsp-types = "0.95"
 rusqlite = { version = "0.32", features = ["bundled"] }
 
 [features]
-default = []
+default = ["ai"]
 vendored-openssl = ["openssl"]
+ai = []
 
 # ═══════════════════════════════════════════════════════════
 # App bundling configuration (cargo-bundle / cargo-packager)

--- a/berrycode/src/app/mod.rs
+++ b/berrycode/src/app/mod.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use tokio::sync::mpsc;
 
 // ===== Submodules =====
+#[cfg(feature = "ai")]
 mod ai_chat;
 pub(crate) mod ansi;
 mod asset_browser;
@@ -44,6 +45,7 @@ pub(crate) mod mobile;
 pub(crate) mod mobile_toolchain;
 mod model_preview;
 pub(crate) mod new_project;
+#[cfg(feature = "ai")]
 mod oracleberry;
 pub(crate) mod package_manager;
 mod peek;
@@ -412,6 +414,7 @@ const MAIN_PANELS: &[SidebarPanel] = &[
         icon: "\u{eb29}", // codicon-package (Docker container metaphor)
         _name: "Docker",
     },
+    #[cfg(feature = "ai")]
     SidebarPanel {
         variant: ActivePanel::OracleBerry,
         icon: "\u{ec1f}", // codicon-lightbulb-sparkle (placeholder until brand SVG)
@@ -471,6 +474,7 @@ pub struct BerryCodeApp {
     pub(crate) docker: docker::DockerState,
 
     // === OracleBerry Panel State ===
+    #[cfg(feature = "ai")]
     pub(crate) oracleberry: oracleberry::OracleBerryState,
 
     // === Search State ===
@@ -924,6 +928,7 @@ pub struct BerryCodeApp {
     pub(crate) lsp_completion_accept_pending: bool,
     /// BYOK provider configuration (Anthropic / OpenAI / Ollama API keys
     /// and selected models). Persisted to `~/.berrycode/ai.json`.
+    #[cfg(feature = "ai")]
     pub(crate) ai_settings: crate::ai::settings::AiSettings,
     /// Cached egui texture for the Scene View activity-bar icon
     /// (rasterised from `assets/icons/scene_view.svg` on first use).
@@ -1745,6 +1750,7 @@ impl BerryCodeApp {
             terminal: terminal_emulator::TerminalEmulator::new(&terminal_working_dir),
             database: database::DatabaseState::default(),
             docker: docker::DockerState::default(),
+            #[cfg(feature = "ai")]
             oracleberry: oracleberry::OracleBerryState::default(),
             search_query: String::new(),
             search_dialog_open: false,
@@ -2100,6 +2106,7 @@ impl BerryCodeApp {
             keybinding_message: None,
             theme_mode: load_theme_mode(),
             lsp_completion_accept_pending: false,
+            #[cfg(feature = "ai")]
             ai_settings: crate::ai::settings::AiSettings::load(),
             scene_view_icon: None,
             database_icon: None,
@@ -2817,6 +2824,7 @@ pub fn berry_ui_system(
         // streaming process output drive what the user sees while typing /
         // watching a build, so a 50ms gap would feel sluggish.
         app.poll_lsp_responses();
+        #[cfg(feature = "ai")]
         app.poll_ai_responses();
         app.poll_run_output();
 
@@ -2965,16 +2973,19 @@ pub fn berry_ui_system(
         } else if app.active_panel == ActivePanel::OracleBerry {
             // AI image generator: sidebar = recent generations,
             // central = prompt + settings + result canvas
-            app.render_sidebar(ctx);
-            egui::CentralPanel::default()
-                .frame(
-                    egui::Frame::NONE
-                        .fill(ui_colors::EDITOR_BG)
-                        .inner_margin(egui::Margin::same(12)),
-                )
-                .show(ctx, |ui| {
-                    app.render_oracleberry_central(ui);
-                });
+            #[cfg(feature = "ai")]
+            {
+                app.render_sidebar(ctx);
+                egui::CentralPanel::default()
+                    .frame(
+                        egui::Frame::NONE
+                            .fill(ui_colors::EDITOR_BG)
+                            .inner_margin(egui::Margin::same(12)),
+                    )
+                    .show(ctx, |ui| {
+                        app.render_oracleberry_central(ui);
+                    });
+            }
         } else if app.active_panel == ActivePanel::Settings {
             // Settings spans the full width: skip the (now-empty) sidebar
             // panel entirely — the activity bar is already rendered above
@@ -2990,6 +3001,7 @@ pub fn berry_ui_system(
                 });
         } else {
             app.render_sidebar(ctx);
+            #[cfg(feature = "ai")]
             app.render_ai_chat_panel(ctx);
             app.render_editor_area(ctx);
         }

--- a/berrycode/src/app/settings.rs
+++ b/berrycode/src/app/settings.rs
@@ -91,12 +91,14 @@ impl BerryCodeApp {
 
                         ui.add_space(12.0);
                         nav_section_header(ui, "Features");
+                        #[cfg(feature = "ai")]
                         nav_item(
                             ui,
                             &mut self.active_settings_tab,
                             super::types::SettingsTab::AiProviders,
                             "AI Providers",
                         );
+                        #[cfg(feature = "ai")]
                         nav_item(
                             ui,
                             &mut self.active_settings_tab,
@@ -265,9 +267,11 @@ impl BerryCodeApp {
                                 }
                             }
                         }
+                        #[cfg(feature = "ai")]
                         super::types::SettingsTab::AiProviders => {
                             self.render_ai_providers_settings(ui);
                         }
+                        #[cfg(feature = "ai")]
                         super::types::SettingsTab::AiUsage => {
                             self.render_ai_usage_settings(ui);
                         }
@@ -276,6 +280,7 @@ impl BerryCodeApp {
         });
     }
 
+    #[cfg(feature = "ai")]
     /// AI Providers settings tab — BYOK configuration. Lets the user
     /// paste API keys for Anthropic / OpenAI, point at a local Ollama
     /// instance, and pick which model handles chat vs inline completion.
@@ -785,6 +790,7 @@ impl BerryCodeApp {
     /// best-effort: the authoritative bill is always whatever the
     /// provider charges, so this tab is for self-monitoring, not
     /// reconciliation.
+    #[cfg(feature = "ai")]
     pub(crate) fn render_ai_usage_settings(&mut self, ui: &mut egui::Ui) {
         let records = crate::ai::usage::load();
 
@@ -902,6 +908,7 @@ impl BerryCodeApp {
 
     /// One stat card used in the AI Usage tab. Mirrors the layout of the
     /// Today / Month columns so they read at a glance.
+    #[cfg(feature = "ai")]
     fn render_usage_card(ui: &mut egui::Ui, title: &str, t: &crate::ai::usage::UsageTotals) {
         egui::Frame::NONE
             .fill(egui::Color32::from_rgb(34, 36, 42))

--- a/berrycode/src/app/sidebar.rs
+++ b/berrycode/src/app/sidebar.rs
@@ -54,6 +54,7 @@ impl BerryCodeApp {
                         self.render_docker_sidebar(ui);
                     }
                     ActivePanel::OracleBerry => {
+                        #[cfg(feature = "ai")]
                         self.render_oracleberry_sidebar(ui);
                     }
                 }

--- a/berrycode/src/app/types.rs
+++ b/berrycode/src/app/types.rs
@@ -126,9 +126,11 @@ pub enum SettingsTab {
     Plugins,
     GitHub,
     /// AI providers: BYOK API keys + model selection (v0.4.5).
+    #[cfg(feature = "ai")]
     AiProviders,
     /// AI usage & cost: per-day / per-month token counts, estimated
     /// USD spend, and a soft monthly cap (v0.4.5).
+    #[cfg(feature = "ai")]
     AiUsage,
 }
 

--- a/berrycode/src/lib.rs
+++ b/berrycode/src/lib.rs
@@ -249,12 +249,14 @@ pub mod syntax;
 pub mod native;
 
 // ===== AI providers (BYOK direct API clients) =====
+#[cfg(feature = "ai")]
 pub mod ai;
 
 // ===== Coding agents (subprocess wrappers around Codex CLI / Claude Code) =====
 // Provides Agent mode, Apply diff, and tool-calling capabilities by
 // shelling out to mature external CLIs rather than reimplementing the
 // agent loop in Rust. v0.4.5 / Phase 4.
+#[cfg(feature = "ai")]
 pub mod agent;
 
 // ===== Common Utilities =====


### PR DESCRIPTION
Some users may not want to use AI features. As such I have added a rust feature that controls if AI features are included.

Verified: cargo check + cargo fmt --check both clean.